### PR TITLE
meson: Add support including SpeexDSP wrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ compile_commands.json
 
 # Universal app bundle output (macOS)
 out
+
+# Meson subprojects
+subprojects/packagecache
+subprojects/speexdsp-*

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,41 @@
+project(
+    'Nuked-SC55-CLAP',
+    'cpp',
+    version: '0.7.0',
+    default_options: [
+        'cpp_std=c++20',
+        'cpp_visibility=hidden',
+        'buildtype=release',
+        'b_lto=true',
+        'b_ndebug=if-release',
+        'b_asneeded=true',
+    ],
+)
+
+sources = files(
+    'src/nuked-sc55/emu.cpp',
+    'src/nuked-sc55/lcd.cpp',
+    'src/nuked-sc55/mcu.cpp',
+    'src/nuked-sc55/mcu_interrupt.cpp',
+    'src/nuked-sc55/mcu_opcodes.cpp',
+    'src/nuked-sc55/mcu_timer.cpp',
+    'src/nuked-sc55/pcm.cpp',
+    'src/nuked-sc55/submcu.cpp',
+    'src/nuked_sc55.cpp',
+    'src/plugin.cpp',
+)
+
+speexdsp_dep = dependency(
+    'speexdsp',
+    fallback: 'speexdsp:speexdsp_dep',
+    default_options: ['default_library=static'],
+)
+
+shared_library(
+    'Nuked-SC55',
+    sources,
+    include_directories: 'include',
+    dependencies: speexdsp_dep,
+    name_prefix: '',
+    name_suffix: 'clap',
+)

--- a/subprojects/speexdsp.wrap
+++ b/subprojects/speexdsp.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = speexdsp-1.2.1
+source_url = https://downloads.xiph.org/releases/speex/speexdsp-1.2.1.tar.gz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/speexdsp_1.2.1-8/speexdsp-1.2.1.tar.gz
+source_filename = speexdsp-1.2.1.tar.gz
+source_hash = 8c777343e4a6399569c72abc38a95b24db56882c83dbdb6c6424a5f4aeb54d3d
+patch_filename = speexdsp_1.2.1-8_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/speexdsp_1.2.1-8/get_patch
+patch_hash = de2332a8cb2ebda12712d3a269c344613263c5275fe5fb4a775663d9f7e8cd8f
+wrapdb_version = 1.2.1-8
+
+[provide]
+speexdsp = speexdsp_dep


### PR DESCRIPTION
> Distro maintainers can follow my instructions (while grinding their teeth, binging on whisky and trying to erase the experience from their memory 🤣 ).

How much whisky are those poor bastards going have to drink?

'Nother round, boys :tumbler_glass: :tumbler_glass: :tumbler_glass: :dizzy_face: 

> Or they can come up with their own Makefile to link statically against Speex -- it's not exactly rocket science for such a small project.

Alcohol consumption prevention team, at your service! :ambulance:  :nerd_face: 

@johnnovak , turns out your repo's layout was very easy to whip up a  Meson build even for a noob like me :-)

This, of course, is a very basic `meson.build` to put to rest any concerns with using vcpkg on Linux (for whatever reasons), and ensure even the most devout Debian users enjoy the Nuked SC55 CLAP plugin :rocket: 

It's standard Meson to build:

**Release build using system SpeexDSP**
 `meson setup build/release && ninja -C build/release`

**Portable build statically-linking SpeexDSP**
 `meson setup --prefer-static build/release && ninja -C build/release`

**Debug build**
 `meson setup --buildtype=debug build/debug && ninja -C build/debug`

**Sanitizer build**
 `meson setup --buildtype=debug -Db_sanitize=address,undefined build/sanitizer && ninja -C build/sanitizer`