### PR TITLE
Synchronize to 0be4ab0 of 'jcmoyer/Nuked-SC55'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,12 +47,12 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v4
         with:
           cmakeVersion: ~3.31.0
           ninjaVersion: latest

--- a/src/nuked-sc55/backend/bounded_ordered_bitset.h
+++ b/src/nuked-sc55/backend/bounded_ordered_bitset.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <bit>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+// Implements an ordered set of integers backed by a single word. This is
+// functionally equivalent to std::set<unsigned_type>, but flat and
+// non-allocating. The tradeoff is that this type only supports values in the
+// range 0..63. It is intended to be used with small, contiguous enumerations
+// like MCU_Interrupt_Source.
+//
+// Example usage:
+//
+// BoundedOrderedBitSet<6> s;
+// s.Include(5);
+// s.Include(0);
+// s.Include(2);
+// for (auto val : s)
+//     printf("%d\n", val);
+//
+// ==> prints 0, 2, 5
+
+template <size_t Bits>
+struct BitsToType;
+
+template <size_t Bits>
+    requires(0 < Bits && Bits <= 8)
+struct BitsToType<Bits>
+{
+    using Type = uint8_t;
+};
+
+template <size_t Bits>
+    requires(8 < Bits && Bits <= 16)
+struct BitsToType<Bits>
+{
+    using Type = uint16_t;
+};
+
+template <size_t Bits>
+    requires(16 < Bits && Bits <= 32)
+struct BitsToType<Bits>
+{
+    using Type = uint32_t;
+};
+
+template <size_t Bits>
+    requires(32 < Bits && Bits <= 64)
+struct BitsToType<Bits>
+{
+    using Type = uint64_t;
+};
+
+// Bits: number of bits in the set. The range of elements is 0..Bits - 1.
+// AccessType: the type to access bits through. May be an enum.
+template <size_t Bits, typename AccessType = typename BitsToType<Bits>::Type>
+struct BoundedOrderedBitSet
+{
+public:
+    using UnderlyingType = typename BitsToType<Bits>::Type;
+
+    int Size() const
+    {
+        return std::popcount(m_set);
+    }
+
+    void Include(const AccessType& item)
+    {
+        assert(item < Bits);
+        m_set |= static_cast<UnderlyingType>(1 << item);
+    }
+
+    void Exclude(const AccessType& item)
+    {
+        assert(item < Bits);
+        m_set &= static_cast<UnderlyingType>(~(1 << item));
+    }
+
+    bool Contains(const AccessType& item) const
+    {
+        assert(item < Bits);
+        return m_set & (1 << item);
+    }
+
+    class Iterator
+    {
+    public:
+        Iterator& operator++()
+        {
+            m_state &= m_state - 1;
+            return *this;
+        }
+
+        AccessType operator*() const
+        {
+            return static_cast<AccessType>(std::countr_zero(m_state));
+        }
+
+        bool operator==(const Iterator& rhs) const
+        {
+            return m_state == rhs.m_state;
+        }
+
+        bool operator!=(const Iterator& rhs) const
+        {
+            return !(*this == rhs);
+        }
+
+    private:
+        Iterator(UnderlyingType state)
+            : m_state(state)
+        {
+        }
+
+        UnderlyingType m_state;
+
+        friend BoundedOrderedBitSet<Bits, AccessType>;
+    };
+
+    Iterator begin() const
+    {
+        return Iterator{m_set};
+    }
+
+    Iterator end() const
+    {
+        return Iterator{0};
+    }
+
+private:
+    UnderlyingType m_set = 0;
+};

--- a/src/nuked-sc55/backend/emu.cpp
+++ b/src/nuked-sc55/backend/emu.cpp
@@ -251,7 +251,7 @@ bool Emulator::LoadRom(RomLocation location, std::span<const uint8_t> source)
             //fprintf(stderr, "FATAL: %s requires a power-of-2 size\n", ToCString(location));
             return false;
         }
-        GetMCU().rom2_mask = (int)source.size() - 1;
+        GetMCU().rom2_mask = (uint32_t)source.size() - 1;
     }
 
     std::copy(source.begin(), source.end(), buffer.begin());

--- a/src/nuked-sc55/backend/lcd.cpp
+++ b/src/nuked-sc55/backend/lcd.cpp
@@ -38,7 +38,7 @@
 #include "lcd_font.h"
 #include <cstring>
 
-void LCD_Enable(lcd_t& lcd, uint32_t enable)
+void LCD_Enable(lcd_t& lcd, bool enable)
 {
     lcd.enable = enable;
 }
@@ -306,7 +306,7 @@ void LCD_FontRenderLR(lcd_t& lcd, uint8_t* LCD_CG, uint8_t ch)
         f = &lcd_font[ch - 16][0];
     else
         f = &LCD_CG[(ch & 7) * 8];
-    int col;
+    uint32_t col;
     if (f[0] & 1)
     {
         col = lcd.color1;

--- a/src/nuked-sc55/backend/lcd.h
+++ b/src/nuked-sc55/backend/lcd.h
@@ -77,7 +77,7 @@ struct lcd_t {
     uint8_t LCD_CG[64]{};
 
     // updated by MCU via LCD_Enable
-    std::atomic<uint8_t> enable = 0;
+    std::atomic<bool> enable = false;
 
     uint32_t buffer[lcd_height_max][lcd_width_max]{};
 
@@ -91,5 +91,5 @@ void LCD_Init(lcd_t& lcd, mcu_t& mcu);
 bool LCD_Start(lcd_t& lcd);
 void LCD_Stop(lcd_t& lcd);
 void LCD_Write(lcd_t& lcd, uint32_t address, uint8_t data);
-void LCD_Enable(lcd_t& lcd, uint32_t enable);
+void LCD_Enable(lcd_t& lcd, bool enable);
 void LCD_Render(lcd_t& lcd);

--- a/src/nuked-sc55/backend/mcu.cpp
+++ b/src/nuked-sc55/backend/mcu.cpp
@@ -153,12 +153,12 @@ READ_RCU:
     exit(1);
 }
 
-void MCU_AnalogSample(mcu_t& mcu, int channel)
+void MCU_AnalogSample(mcu_t& mcu, uint8_t channel)
 {
-    int value = MCU_AnalogReadPin(mcu, channel);
-    int dest = (channel << 1) & 6;
-    mcu.dev_register[DEV_ADDRAH + dest] = value >> 2;
-    mcu.dev_register[DEV_ADDRAL + dest] = (value << 6) & 0xc0;
+    uint16_t value = MCU_AnalogReadPin(mcu, channel);
+    uint16_t dest = (channel << 1) & 6;
+    mcu.dev_register[DEV_ADDRAH + dest] = (uint8_t)(value >> 2);
+    mcu.dev_register[DEV_ADDRAL + dest] = (uint8_t)((value << 6) & 0xc0);
 }
 
 void MCU_DeviceWrite(mcu_t& mcu, uint32_t address, uint8_t data)
@@ -190,7 +190,7 @@ void MCU_DeviceWrite(mcu_t& mcu, uint32_t address, uint8_t data)
         break;
     case DEV_P9DDR:
         break;
-    case DEV_RAME: // RAME
+    case DEV_RAMCR:
         break;
     case DEV_P1CR: // P1CR
         break;
@@ -333,13 +333,13 @@ uint8_t MCU_DeviceRead(mcu_t& mcu, uint32_t address)
     }
     case DEV_P9DR:
     {
-        int cfg = 0;
+        uint8_t cfg = 0;
         if (!mcu.is_mk1)
             cfg = mcu.is_sc155 ? 0 : 2; // bit 1: 0 - SC-155mk2 (???), 1 - SC-55mk2
 
-        int dir = mcu.dev_register[DEV_P9DDR];
+        uint8_t dir = mcu.dev_register[DEV_P9DDR];
 
-        int val = cfg & (dir ^ 0xff);
+        uint8_t val = cfg & (dir ^ 0xff);
         val |= mcu.dev_register[DEV_P9DR] & dir;
         return val;
     }
@@ -351,14 +351,6 @@ uint8_t MCU_DeviceRead(mcu_t& mcu, uint32_t address)
     case DEV_IPRD:
     case DEV_DTEC:
     case DEV_DTED:
-    case DEV_FRT2_TCSR:
-    case DEV_FRT1_TCSR:
-    case DEV_FRT1_TCR:
-    case DEV_FRT1_FRCH:
-    case DEV_FRT1_FRCL:
-    case DEV_FRT3_TCSR:
-    case DEV_FRT3_OCRAH:
-    case DEV_FRT3_OCRAL:
         return mcu.dev_register[address];
     }
     return mcu.dev_register[address];
@@ -366,16 +358,71 @@ uint8_t MCU_DeviceRead(mcu_t& mcu, uint32_t address)
 
 void MCU_DeviceReset(mcu_t& mcu)
 {
-    // mcu.dev_register[0x00] = 0x03;
-    // mcu.dev_register[0x7c] = 0x87;
-    mcu.dev_register[DEV_RAME] = 0x80;
-    mcu.dev_register[DEV_SSR] = 0x80;
+    mcu.dev_register[DEV_P1DDR] = 0x03;
+    mcu.dev_register[DEV_P1DR]  = 0;
+    mcu.dev_register[DEV_P1CR]  = 0x87;
+
+    mcu.dev_register[DEV_P2DDR] = 0xE0;
+    mcu.dev_register[DEV_P2DR]  = 0xE0;
+
+    mcu.dev_register[DEV_P3DDR] = 0;
+    mcu.dev_register[DEV_P3DR]  = 0;
+
+    mcu.dev_register[DEV_P4DDR] = 0;
+    mcu.dev_register[DEV_P4DR]  = 0;
+
+    mcu.dev_register[DEV_P5DDR] = 0;
+    mcu.dev_register[DEV_P5DR]  = 0;
+
+    mcu.dev_register[DEV_P6DDR] = 0xF0;
+    mcu.dev_register[DEV_P6DR]  = 0xF0;
+
+    mcu.dev_register[DEV_P7DDR] = 0;
+    mcu.dev_register[DEV_P7DR]  = 0;
+
+    mcu.dev_register[DEV_P8DR] = 0;
+
+    mcu.dev_register[DEV_P9DDR] = 0;
+    mcu.dev_register[DEV_P9DR]  = 0;
+
+    // dev_register bypassed for timers
+    TIMER_Reset(*mcu.timer);
+
+    mcu.dev_register[DEV_RDR] = 0;
+    mcu.dev_register[DEV_TDR] = 0xFF;
+    mcu.dev_register[DEV_SMR] = 0x04;
+    mcu.dev_register[DEV_SCR] = 0x0C;
+    mcu.dev_register[DEV_SSR] = 0x87;
+    mcu.dev_register[DEV_BRR] = 0xFF;
+
+    mcu.dev_register[DEV_ADDRAH] = 0;
+    mcu.dev_register[DEV_ADDRAL] = 0;
+    mcu.dev_register[DEV_ADDRBH] = 0;
+    mcu.dev_register[DEV_ADDRBL] = 0;
+    mcu.dev_register[DEV_ADDRCH] = 0;
+    mcu.dev_register[DEV_ADDRCL] = 0;
+    mcu.dev_register[DEV_ADDRDH] = 0;
+    mcu.dev_register[DEV_ADDRDL] = 0;
+    mcu.dev_register[DEV_ADCSR]  = 0;
+
+    mcu.dev_register[DEV_IPRA] = 0;
+    mcu.dev_register[DEV_IPRB] = 0;
+    mcu.dev_register[DEV_IPRC] = 0;
+    mcu.dev_register[DEV_IPRD] = 0;
+    mcu.dev_register[DEV_DTEA] = 0;
+    mcu.dev_register[DEV_DTEB] = 0;
+    mcu.dev_register[DEV_DTEC] = 0;
+    mcu.dev_register[DEV_DTED] = 0;
+
+    mcu.dev_register[DEV_WCR] = 0xF3;
+
+    mcu.dev_register[DEV_RAMCR] = 0x80;
 }
 
 void MCU_UpdateAnalog(mcu_t& mcu, uint64_t cycles)
 {
-    int ctrl = mcu.dev_register[DEV_ADCSR];
-    int isscan = (ctrl & 16) != 0;
+    const uint8_t ctrl = mcu.dev_register[DEV_ADCSR];
+    const bool isscan = (ctrl & 16) != 0;
 
     if (ctrl & 0x20)
     {
@@ -385,8 +432,8 @@ void MCU_UpdateAnalog(mcu_t& mcu, uint64_t cycles)
         {
             if (isscan)
             {
-                int base = ctrl & 4;
-                for (int i = 0; i <= (ctrl & 3); i++)
+                uint8_t base = ctrl & 4;
+                for (uint8_t i = 0; i <= (ctrl & 3); i++)
                     MCU_AnalogSample(mcu, base + i);
                 mcu.analog_end_time = cycles + 200;
             }
@@ -423,11 +470,11 @@ uint8_t MCU_Read(mcu_t& mcu, uint32_t address)
             if (!mcu.is_mk1)
             {
                 uint16_t base = mcu.is_jv880 ? 0xf000 : 0xe000;
-                if (address >= base && address < (base | 0x400))
+                if (address >= base && address < (base | 0x400u))
                 {
                     ret = PCM_Read(*mcu.pcm, address & 0x3f);
                 }
-                else if (!mcu.is_scb55 && address >= 0xec00 && address < 0xf000)
+                else if (!mcu.is_scb55 && address >= 0xec00u && address < 0xf000u)
                 {
                     ret = SM_SysRead(*mcu.sm, address & 0xff);
                 }
@@ -435,16 +482,16 @@ uint8_t MCU_Read(mcu_t& mcu, uint32_t address)
                 {
                     ret = MCU_DeviceRead(mcu, address & 0x7f);
                 }
-                else if (address >= 0xfb80 && address < 0xff80
-                    && (mcu.dev_register[DEV_RAME] & 0x80) != 0)
+                else if (address >= 0xfb80u && address < 0xff80u
+                    && (mcu.dev_register[DEV_RAMCR] & 0x80) != 0)
                     ret = mcu.ram[(address - 0xfb80) & 0x3ff];
-                else if (address >= 0x8000 && address < 0xe000)
+                else if (address >= 0x8000u && address < 0xe000u)
                 {
                     ret = mcu.sram[address & 0x7fff];
                 }
-                else if (address == (base | 0x402))
+                else if (address == (base | 0x402u))
                 {
-                    ret = mcu.ga_int_trigger;
+                    ret = (uint8_t)mcu.ga_int_trigger;
                     mcu.ga_int_trigger = 0;
                     MCU_Interrupt_SetRequest(mcu, mcu.is_jv880 ? INTERRUPT_SOURCE_IRQ0 : INTERRUPT_SOURCE_IRQ1, 0);
                 }
@@ -468,7 +515,7 @@ uint8_t MCU_Read(mcu_t& mcu, uint32_t address)
                     ret = MCU_DeviceRead(mcu, address & 0x7f);
                 }
                 else if (address >= 0xfb80 && address < 0xff80
-                    && (mcu.dev_register[DEV_RAME] & 0x80) != 0)
+                    && (mcu.dev_register[DEV_RAMCR] & 0x80) != 0)
                 {
                     ret = mcu.ram[(address - 0xfb80) & 0x3ff];
                 }
@@ -495,12 +542,12 @@ uint8_t MCU_Read(mcu_t& mcu, uint32_t address)
                     if ((mcu.io_sd & 4) == 0)
                         data &= ((button_pressed >> 16) & 255) ^ 255;
                     if ((mcu.io_sd & 8) == 0)
-                        data &= ((button_pressed >> 24) & 255) ^ 255;
+                        data &= (uint8_t)(((button_pressed >> 24) & 255) ^ 255);
                     return data;
                 }
                 else if (address == 0xf106)
                 {
-                    ret = mcu.ga_int_trigger;
+                    ret = (uint8_t)mcu.ga_int_trigger;
                     mcu.ga_int_trigger = 0;
                     MCU_Interrupt_SetRequest(mcu, INTERRUPT_SOURCE_IRQ1, 0);
                 }
@@ -589,22 +636,22 @@ uint8_t MCU_Read(mcu_t& mcu, uint32_t address)
 
 uint16_t MCU_Read16(mcu_t& mcu, uint32_t address)
 {
-    address &= ~1;
+    address &= ~1u;
     uint8_t b0, b1;
     b0 = MCU_Read(mcu, address);
     b1 = MCU_Read(mcu, address+1);
-    return (b0 << 8) + b1;
+    return (uint16_t)((b0 << 8) + b1);
 }
 
 uint32_t MCU_Read32(mcu_t& mcu, uint32_t address)
 {
-    address &= ~3;
+    address &= ~3u;
     uint8_t b0, b1, b2, b3;
     b0 = MCU_Read(mcu, address);
     b1 = MCU_Read(mcu, address+1);
     b2 = MCU_Read(mcu, address+2);
     b3 = MCU_Read(mcu, address+3);
-    return (b0 << 24) + (b1 << 16) + (b2 << 8) + b3;
+    return (uint32_t)((b0 << 24) + (b1 << 16) + (b2 << 8) + b3);
 }
 
 void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value)
@@ -617,18 +664,18 @@ void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value)
         {
             if (!mcu.is_mk1)
             {
-                uint16_t base = mcu.is_jv880 ? 0xf000 : 0xe000;
-                if (address >= (base | 0x400) && address < (base | 0x800))
+                uint16_t base = mcu.is_jv880 ? 0xf000u : 0xe000u;
+                if (address >= (base | 0x400u) && address < (base | 0x800u))
                 {
-                    if (address == (base | 0x404) || address == (base | 0x405))
+                    if (address == (base | 0x404u) || address == (base | 0x405u))
                         LCD_Write(*mcu.lcd, address & 1, value);
-                    else if (address == (base | 0x401))
+                    else if (address == (base | 0x401u))
                     {
                         mcu.io_sd = value;
                         LCD_Enable(*mcu.lcd, (value & 1) == 0);
                     }
-                    else if (address == (base | 0x402))
-                        mcu.ga_int_enable = (value << 1);
+                    else if (address == (base | 0x402u))
+                        mcu.ga_int_enable = (uint8_t)(value << 1);
                     //else
                     //    fprintf(stderr, "Unknown write %x %x\n", address, value);
                     //
@@ -642,7 +689,7 @@ void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value)
                     // e407: 0, e406 continuation?
                     //
                 }
-                else if (address >= (base | 0x000) && address < (base | 0x400))
+                else if (address >= (base | 0x000u) && address < (base | 0x400u))
                 {
                     PCM_Write(*mcu.pcm, address & 0x3f, value);
                 }
@@ -655,7 +702,7 @@ void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value)
                     MCU_DeviceWrite(mcu, address & 0x7f, value);
                 }
                 else if (address >= 0xfb80 && address < 0xff80
-                    && (mcu.dev_register[DEV_RAME] & 0x80) != 0)
+                    && (mcu.dev_register[DEV_RAMCR] & 0x80) != 0)
                 {
                     mcu.ram[(address - 0xfb80) & 0x3ff] = value;
                 }
@@ -679,7 +726,7 @@ void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value)
                     MCU_DeviceWrite(mcu, address & 0x7f, value);
                 }
                 else if (address >= 0xfb80 && address < 0xff80
-                    && (mcu.dev_register[DEV_RAME] & 0x80) != 0)
+                    && (mcu.dev_register[DEV_RAMCR] & 0x80) != 0)
                 {
                     mcu.ram[(address - 0xfb80) & 0x3ff] = value;
                 }
@@ -739,15 +786,15 @@ void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value)
     }
     else
     {
-        //fprintf(stderr, "Unknown write %x %x\n", (page << 16) | address, value);
+        //fprintf(stderr, "Unknown write %x %x\n", (uint32_t)(page << 16) | address, value);
     }
 }
 
 void MCU_Write16(mcu_t& mcu, uint32_t address, uint16_t value)
 {
-    address &= ~1;
-    MCU_Write(mcu, address, value >> 8);
-    MCU_Write(mcu, address + 1, value & 0xff);
+    address &= ~1u;
+    MCU_Write(mcu, address, (uint8_t)(value >> 8));
+    MCU_Write(mcu, address + 1, (uint8_t)(value & 0xff));
 }
 
 void MCU_ReadInstruction(mcu_t& mcu)
@@ -806,7 +853,7 @@ void MCU_Reset(mcu_t& mcu)
     mcu.cp = (reset_address >> 16) & 0xff;
     mcu.pc = reset_address & 0xffff;
 
-    mcu.exception_pending = -1;
+    mcu.exception_pending = (MCU_Exception_Source)-1;
 
     MCU_DeviceReset(mcu);
 
@@ -928,7 +975,7 @@ uint8_t MCU_ReadP1(mcu_t& mcu)
     if ((mcu.p0_data & 4) == 0)
         data &= ((button_pressed >> 16) & 255) ^ 255;
     if ((mcu.p0_data & 8) == 0)
-        data &= ((button_pressed >> 24) & 255) ^ 255;
+        data &= (uint8_t)(((button_pressed >> 24) & 255) ^ 255);
 
     return data;
 }
@@ -948,7 +995,7 @@ void MCU_PostSample(mcu_t& mcu, const AudioFrame<int32_t>& frame)
     mcu.sample_callback(mcu.callback_userdata, frame);
 }
 
-void MCU_GA_SetGAInt(mcu_t& mcu, int line, int value)
+void MCU_GA_SetGAInt(mcu_t& mcu, uint8_t line, bool value)
 {
     // guesswork
     if (value && !mcu.ga_int[line] && (mcu.ga_int_enable & (1 << line)) != 0)
@@ -981,30 +1028,32 @@ void MCU_SetRomset(mcu_t& mcu, Romset romset)
     switch (romset)
     {
     case Romset::MK2:
+        break;
     case Romset::SC155MK2:
-        if (romset == Romset::SC155MK2)
-            mcu.is_sc155 = true;
+        mcu.is_sc155 = true;
         break;
     case Romset::ST:
         mcu.is_st = true;
         break;
     case Romset::MK1:
-    case Romset::SC155:
         mcu.is_mk1 = true;
-        mcu.is_st  = false;
-        if (romset == Romset::SC155)
-            mcu.is_sc155 = true;
+        break;
+    case Romset::SC155:
+        mcu.is_mk1   = true;
+        mcu.is_sc155 = true;
         break;
     case Romset::CM300:
         mcu.is_mk1   = true;
         mcu.is_cm300 = true;
         break;
     case Romset::JV880:
-        mcu.is_jv880   = true;
+        mcu.is_jv880 = true;
         break;
     case Romset::SCB55:
     case Romset::RLP3237:
         mcu.is_scb55 = true;
         break;
     }
+
+    TIMER_NotifyRomsetChange(*mcu.timer);
 }

--- a/src/nuked-sc55/backend/mcu.h
+++ b/src/nuked-sc55/backend/mcu.h
@@ -35,8 +35,10 @@
 #pragma once
 
 #include "audio.h"
+#include "bounded_ordered_bitset.h"
 #include "mcu_interrupt.h"
 #include "rom.h"
+#include "mcu_opcodes.h"
 #include <atomic>
 #include <cstdint>
 
@@ -45,69 +47,100 @@ struct pcm_t;
 struct mcu_timer_t;
 struct lcd_t;
 
-enum {
-    DEV_P1DDR = 0x00,
-    DEV_P5DDR = 0x08,
-    DEV_P6DDR = 0x09,
-    DEV_P7DDR = 0x0c,
-    DEV_P7DR = 0x0e,
-    DEV_FRT1_TCR = 0x10,
-    DEV_FRT1_TCSR = 0x11,
-    DEV_FRT1_FRCH = 0x12,
-    DEV_FRT1_FRCL = 0x13,
+// Values are byte offsets from the start of register fields in memory
+// (ff80..ffff) to the field named by the enumeration item. This enumeration
+// also acts as an index type for mcu.dev_register. Not all of these indices
+// are used. Notably, timers are handled by the mcu_timer module instead and
+// their data in dev_register will hold an unspecified value.
+enum MCU_Register_Field : uint8_t
+{
+    DEV_P1DDR      = 0x00,
+    DEV_P2DDR      = 0x01,
+    DEV_P1DR       = 0x02,
+    DEV_P2DR       = 0x03,
+    DEV_P3DDR      = 0x04,
+    DEV_P4DDR      = 0x05,
+    DEV_P3DR       = 0x06,
+    DEV_P4DR       = 0x07,
+    DEV_P5DDR      = 0x08,
+    DEV_P6DDR      = 0x09,
+    DEV_P5DR       = 0x0a,
+    DEV_P6DR       = 0x0b,
+    DEV_P7DDR      = 0x0c,
+    DEV_P7DR       = 0x0e,
+    DEV_P8DR       = 0x0f,
+    DEV_FRT1_TCR   = 0x10,
+    DEV_FRT1_TCSR  = 0x11,
+    DEV_FRT1_FRCH  = 0x12,
+    DEV_FRT1_FRCL  = 0x13,
     DEV_FRT1_OCRAH = 0x14,
     DEV_FRT1_OCRAL = 0x15,
-    DEV_FRT2_TCR = 0x20,
-    DEV_FRT2_TCSR = 0x21,
-    DEV_FRT2_FRCH = 0x22,
-    DEV_FRT2_FRCL = 0x23,
+    DEV_FRT1_OCRBH = 0x16,
+    DEV_FRT1_OCRBL = 0x17,
+    DEV_FRT1_ICRH  = 0x18,
+    DEV_FRT1_ICRL  = 0x19,
+    DEV_FRT2_TCR   = 0x20,
+    DEV_FRT2_TCSR  = 0x21,
+    DEV_FRT2_FRCH  = 0x22,
+    DEV_FRT2_FRCL  = 0x23,
     DEV_FRT2_OCRAH = 0x24,
     DEV_FRT2_OCRAL = 0x25,
-    DEV_FRT3_TCR = 0x30,
-    DEV_FRT3_TCSR = 0x31,
-    DEV_FRT3_FRCH = 0x32,
-    DEV_FRT3_FRCL = 0x33,
+    DEV_FRT2_OCRBH = 0x26,
+    DEV_FRT2_OCRBL = 0x27,
+    DEV_FRT2_ICRH  = 0x28,
+    DEV_FRT2_ICRL  = 0x29,
+    DEV_FRT3_TCR   = 0x30,
+    DEV_FRT3_TCSR  = 0x31,
+    DEV_FRT3_FRCH  = 0x32,
+    DEV_FRT3_FRCL  = 0x33,
     DEV_FRT3_OCRAH = 0x34,
     DEV_FRT3_OCRAL = 0x35,
-    DEV_PWM1_TCR = 0x40,
-    DEV_PWM1_DTR = 0x41,
-    DEV_PWM2_TCR = 0x44,
-    DEV_PWM2_DTR = 0x45,
-    DEV_PWM3_TCR = 0x48,
-    DEV_PWM3_DTR = 0x49,
-    DEV_TMR_TCR = 0x50,
-    DEV_TMR_TCSR = 0x51,
-    DEV_TMR_TCORA = 0x52,
-    DEV_TMR_TCORB = 0x53,
-    DEV_TMR_TCNT = 0x54,
-    DEV_SMR = 0x58,
-    DEV_BRR = 0x59,
-    DEV_SCR = 0x5a,
-    DEV_TDR = 0x5b,
-    DEV_SSR = 0x5c,
-    DEV_RDR = 0x5d,
-    DEV_ADDRAH = 0x60,
-    DEV_ADDRAL = 0x61,
-    DEV_ADDRBH = 0x62,
-    DEV_ADDRBL = 0x63,
-    DEV_ADDRCH = 0x64,
-    DEV_ADDRCL = 0x65,
-    DEV_ADDRDH = 0x66,
-    DEV_ADDRDL = 0x67,
-    DEV_ADCSR = 0x68,
-    DEV_IPRA = 0x70,
-    DEV_IPRB = 0x71,
-    DEV_IPRC = 0x72,
-    DEV_IPRD = 0x73,
-    DEV_DTEA = 0x74,
-    DEV_DTEB = 0x75,
-    DEV_DTEC = 0x76,
-    DEV_DTED = 0x77,
-    DEV_WCR = 0x78,
-    DEV_RAME = 0x79,
-    DEV_P1CR = 0x7c,
-    DEV_P9DDR = 0x7e,
-    DEV_P9DR = 0x7f,
+    DEV_FRT3_OCRBH = 0x36,
+    DEV_FRT3_OCRBL = 0x37,
+    DEV_FRT3_ICRH  = 0x38,
+    DEV_FRT3_ICRL  = 0x39,
+    DEV_PWM1_TCR   = 0x40,
+    DEV_PWM1_DTR   = 0x41,
+    DEV_PWM1_TCNT  = 0x42,
+    DEV_PWM2_TCR   = 0x44,
+    DEV_PWM2_DTR   = 0x45,
+    DEV_PWM2_TCNT  = 0x46,
+    DEV_PWM3_TCR   = 0x48,
+    DEV_PWM3_DTR   = 0x49,
+    DEV_PWM3_TCNT  = 0x4a,
+    DEV_TMR_TCR    = 0x50,
+    DEV_TMR_TCSR   = 0x51,
+    DEV_TMR_TCORA  = 0x52,
+    DEV_TMR_TCORB  = 0x53,
+    DEV_TMR_TCNT   = 0x54,
+    DEV_SMR        = 0x58,
+    DEV_BRR        = 0x59,
+    DEV_SCR        = 0x5a,
+    DEV_TDR        = 0x5b,
+    DEV_SSR        = 0x5c,
+    DEV_RDR        = 0x5d,
+    DEV_ADDRAH     = 0x60,
+    DEV_ADDRAL     = 0x61,
+    DEV_ADDRBH     = 0x62,
+    DEV_ADDRBL     = 0x63,
+    DEV_ADDRCH     = 0x64,
+    DEV_ADDRCL     = 0x65,
+    DEV_ADDRDH     = 0x66,
+    DEV_ADDRDL     = 0x67,
+    DEV_ADCSR      = 0x68,
+    DEV_IPRA       = 0x70,
+    DEV_IPRB       = 0x71,
+    DEV_IPRC       = 0x72,
+    DEV_IPRD       = 0x73,
+    DEV_DTEA       = 0x74,
+    DEV_DTEB       = 0x75,
+    DEV_DTEC       = 0x76,
+    DEV_DTED       = 0x77,
+    DEV_WCR        = 0x78,
+    DEV_RAMCR      = 0x79,
+    DEV_P1CR       = 0x7c,
+    DEV_P9DDR      = 0x7e,
+    DEV_P9DR       = 0x7f,
 };
 
 const uint16_t sr_mask = 0x870f;
@@ -201,9 +234,9 @@ struct mcu_t {
     uint8_t cp = 0, dp = 0, ep = 0, tp = 0, br = 0;
     uint8_t sleep = 0;
     uint8_t ex_ignore = 0;
-    int32_t exception_pending = 0;
-    uint8_t interrupt_pending[INTERRUPT_SOURCE_MAX]{};
-    uint8_t trapa_pending[16]{};
+    MCU_Exception_Source exception_pending{};
+    BoundedOrderedBitSet<INTERRUPT_SOURCE_MAX, MCU_Interrupt_Source> interrupt_pending;
+    BoundedOrderedBitSet<16> trapa_pending;
     uint64_t cycles = 0;
 
     uint8_t rom1[ROM1_SIZE]{};
@@ -235,19 +268,19 @@ struct mcu_t {
 
     Romset romset = Romset::MK2;
 
-    int is_mk1 = 0; // 0 - SC-55mkII, SC-55ST. 1 - SC-55, CM-300/SCC-1
-    int is_cm300 = 0; // 0 - SC-55, 1 - CM-300/SCC-1
-    int is_st = 0; // 0 - SC-55mk2, 1 - SC-55ST
-    int is_jv880 = 0; // 0 - SC-55, 1 - JV880
-    int is_scb55 = 0; // 0 - sub mcu (e.g SC-55mk2), 1 - no sub mcu (e.g SCB-55)
-    int is_sc155 = 0; // 0 - SC-55(MK2), 1 - SC-155(MK2)
+    bool is_mk1 = false; // 0 - SC-55mkII, SC-55ST. 1 - SC-55, CM-300/SCC-1
+    bool is_cm300 = false; // 0 - SC-55, 1 - CM-300/SCC-1
+    bool is_st = false; // 0 - SC-55mk2, 1 - SC-55ST
+    bool is_jv880 = false; // 0 - SC-55, 1 - JV880
+    bool is_scb55 = false; // 0 - sub mcu (e.g SC-55mk2), 1 - no sub mcu (e.g SCB-55)
+    bool is_sc155 = false; // 0 - SC-55(MK2), 1 - SC-155(MK2)
 
-    int rom2_mask = ROM2_SIZE - 1;
+    uint32_t rom2_mask = ROM2_SIZE - 1;
 
-    int ga_int[8]{};
-    int ga_int_enable = 0;
-    int ga_int_trigger = 0;
-    int ga_lcd_counter = 0;
+    bool ga_int[8]{};
+    uint8_t ga_int_enable = 0; // mask of ga_int indices
+    uint8_t ga_int_trigger = 0; // index into ga_int
+    int ga_lcd_counter = 0; // timer range 0..500, decrements to 0
 
     std::atomic<uint32_t> button_pressed;
 
@@ -263,7 +296,7 @@ struct mcu_t {
     uint32_t operand_type = 0;
     uint16_t operand_ea = 0;
     uint8_t operand_ep = 0;
-    uint8_t operand_size = 0;
+    MCU_Operand_Size operand_size{};
     uint8_t operand_reg = 0;
     uint8_t operand_status = 0;
     uint16_t operand_data = 0;
@@ -310,7 +343,7 @@ inline uint32_t MCU_GetVectorAddress(mcu_t& mcu, uint32_t vector)
     return MCU_Read32(mcu, vector * 4);
 }
 
-inline uint32_t MCU_GetPageForRegister(mcu_t& mcu, uint32_t reg)
+inline uint8_t MCU_GetPageForRegister(mcu_t& mcu, uint8_t reg)
 {
     if (reg >= 6)
         return mcu.tp;
@@ -319,10 +352,11 @@ inline uint32_t MCU_GetPageForRegister(mcu_t& mcu, uint32_t reg)
     return mcu.dp;
 }
 
-inline void MCU_ControlRegisterWrite(mcu_t& mcu, uint32_t reg, uint32_t siz, uint32_t data)
+inline void MCU_ControlRegisterWrite(mcu_t& mcu, uint32_t reg, MCU_Operand_Size siz, uint32_t data)
 {
-    if (siz)
+    switch (siz)
     {
+    case MCU_Operand_Size::WORD:
         if (reg == 0)
         {
             mcu.sr = (uint16_t)data;
@@ -344,9 +378,8 @@ inline void MCU_ControlRegisterWrite(mcu_t& mcu, uint32_t reg, uint32_t siz, uin
         {
             MCU_ErrorTrap(mcu);
         }
-    }
-    else
-    {
+        break;
+    case MCU_Operand_Size::BYTE:
         if (reg == 1)
         {
             mcu.sr &= ~0xff;
@@ -373,14 +406,16 @@ inline void MCU_ControlRegisterWrite(mcu_t& mcu, uint32_t reg, uint32_t siz, uin
         {
             MCU_ErrorTrap(mcu);
         }
+        break;
     }
 }
 
-inline uint32_t MCU_ControlRegisterRead(mcu_t& mcu, uint32_t reg, uint32_t siz)
+inline uint32_t MCU_ControlRegisterRead(mcu_t& mcu, uint32_t reg, MCU_Operand_Size siz)
 {
     uint32_t ret = 0;
-    if (siz)
+    switch (siz)
     {
+    case MCU_Operand_Size::WORD:
         if (reg == 0)
         {
             ret = mcu.sr & sr_mask;
@@ -395,16 +430,15 @@ inline uint32_t MCU_ControlRegisterRead(mcu_t& mcu, uint32_t reg, uint32_t siz)
         }
         else if (reg == 3) // FIXME: undocumented
         {
-            ret = (uint32_t)mcu.br | ((uint32_t)mcu.br << 8);;
+            ret = (uint32_t)mcu.br | ((uint32_t)mcu.br << 8);
         }
         else
         {
             MCU_ErrorTrap(mcu);
         }
         ret &= 0xffff;
-    }
-    else
-    {
+        break;
+    case MCU_Operand_Size::BYTE:
         if (reg == 1)
         {
             ret = mcu.sr & sr_mask;
@@ -430,16 +464,17 @@ inline uint32_t MCU_ControlRegisterRead(mcu_t& mcu, uint32_t reg, uint32_t siz)
             MCU_ErrorTrap(mcu);
         }
         ret &= 0xff;
+        break;
     }
     return ret;
 }
 
-inline void MCU_SetStatus(mcu_t& mcu, uint32_t condition, uint32_t mask)
+inline void MCU_SetStatus(mcu_t& mcu, bool condition, uint16_t mask)
 {
     if (condition)
-        mcu.sr |= (uint16_t)mask;
+        mcu.sr |= mask;
     else
-        mcu.sr &= (uint16_t)(~mask);
+        mcu.sr &= ~mask;
 }
 
 inline void MCU_PushStack(mcu_t& mcu, uint16_t data)
@@ -521,7 +556,7 @@ uint8_t MCU_ReadP0(mcu_t& mcu);
 uint8_t MCU_ReadP1(mcu_t& mcu);
 void MCU_WriteP0(mcu_t& mcu, uint8_t data);
 void MCU_WriteP1(mcu_t& mcu, uint8_t data);
-void MCU_GA_SetGAInt(mcu_t& mcu, int line, int value);
+void MCU_GA_SetGAInt(mcu_t& mcu, uint8_t line, bool value);
 
 void MCU_EncoderTrigger(mcu_t& mcu, int dir);
 

--- a/src/nuked-sc55/backend/mcu_interrupt.cpp
+++ b/src/nuked-sc55/backend/mcu_interrupt.cpp
@@ -44,17 +44,24 @@ void MCU_Interrupt_Start(mcu_t& mcu, int32_t mask)
     if (mask >= 0)
     {
         mcu.sr &= ~STATUS_INT_MASK;
-        mcu.sr |= mask << 8;
+        mcu.sr |= (uint16_t)(mask << 8);
     }
     mcu.sleep = 0;
 }
 
-void MCU_Interrupt_SetRequest(mcu_t& mcu, uint32_t interrupt, uint32_t value)
+void MCU_Interrupt_SetRequest(mcu_t& mcu, MCU_Interrupt_Source interrupt, bool value)
 {
-    mcu.interrupt_pending[interrupt] = value;
+    if (value)
+    {
+        mcu.interrupt_pending.Include(interrupt);
+    }
+    else
+    {
+        mcu.interrupt_pending.Exclude(interrupt);
+    }
 }
 
-void MCU_Interrupt_Exception(mcu_t& mcu, uint32_t exception)
+void MCU_Interrupt_Exception(mcu_t& mcu, MCU_Exception_Source exception)
 {
 #if 0
     if (interrupt == INTERRUPT_SOURCE_IRQ0 && (mcu.dev_register[DEV_P1CR] & 0x20) == 0)
@@ -65,17 +72,98 @@ void MCU_Interrupt_Exception(mcu_t& mcu, uint32_t exception)
     mcu.exception_pending = exception;
 }
 
-void MCU_Interrupt_TRAPA(mcu_t& mcu, uint32_t vector)
+void MCU_Interrupt_TRAPA(mcu_t& mcu, uint8_t vector)
 {
-    mcu.trapa_pending[vector] = 1;
+    mcu.trapa_pending.Include(vector);
 }
 
 void MCU_Interrupt_StartVector(mcu_t& mcu, uint32_t vector, int32_t mask)
 {
     uint32_t address = MCU_GetVectorAddress(mcu, vector);
     MCU_Interrupt_Start(mcu, mask);
-    mcu.cp = address >> 16;
-    mcu.pc = address;
+    mcu.cp = (uint8_t)(address >> 16);
+    mcu.pc = (uint16_t)address;
+}
+
+static void MCU_Interrupt_GetVL(const mcu_t& mcu, uint32_t source, int32_t& vector, int32_t& level)
+{
+    switch (source)
+    {
+    case INTERRUPT_SOURCE_IRQ0:
+        if ((mcu.dev_register[DEV_P1CR] & 0x20) == 0)
+            break;
+        vector = VECTOR_IRQ0;
+        level  = (mcu.dev_register[DEV_IPRA] >> 4) & 7;
+        break;
+    case INTERRUPT_SOURCE_IRQ1:
+        if ((mcu.dev_register[DEV_P1CR] & 0x40) == 0)
+            break;
+        vector = VECTOR_IRQ1;
+        level  = (mcu.dev_register[DEV_IPRA] >> 0) & 7;
+        break;
+    case INTERRUPT_SOURCE_FRT0_OCIA:
+        vector = VECTOR_INTERNAL_INTERRUPT_94;
+        level  = (mcu.dev_register[DEV_IPRB] >> 4) & 7;
+        break;
+    case INTERRUPT_SOURCE_FRT0_OCIB:
+        vector = VECTOR_INTERNAL_INTERRUPT_98;
+        level  = (mcu.dev_register[DEV_IPRB] >> 4) & 7;
+        break;
+    case INTERRUPT_SOURCE_FRT0_FOVI:
+        vector = VECTOR_INTERNAL_INTERRUPT_9C;
+        level  = (mcu.dev_register[DEV_IPRB] >> 4) & 7;
+        break;
+    case INTERRUPT_SOURCE_FRT1_OCIA:
+        vector = VECTOR_INTERNAL_INTERRUPT_A4;
+        level  = (mcu.dev_register[DEV_IPRB] >> 0) & 7;
+        break;
+    case INTERRUPT_SOURCE_FRT1_OCIB:
+        vector = VECTOR_INTERNAL_INTERRUPT_A8;
+        level  = (mcu.dev_register[DEV_IPRB] >> 0) & 7;
+        break;
+    case INTERRUPT_SOURCE_FRT1_FOVI:
+        vector = VECTOR_INTERNAL_INTERRUPT_AC;
+        level  = (mcu.dev_register[DEV_IPRB] >> 0) & 7;
+        break;
+    case INTERRUPT_SOURCE_FRT2_OCIA:
+        vector = VECTOR_INTERNAL_INTERRUPT_B4;
+        level  = (mcu.dev_register[DEV_IPRC] >> 4) & 7;
+        break;
+    case INTERRUPT_SOURCE_FRT2_OCIB:
+        vector = VECTOR_INTERNAL_INTERRUPT_B8;
+        level  = (mcu.dev_register[DEV_IPRC] >> 4) & 7;
+        break;
+    case INTERRUPT_SOURCE_FRT2_FOVI:
+        vector = VECTOR_INTERNAL_INTERRUPT_BC;
+        level  = (mcu.dev_register[DEV_IPRC] >> 4) & 7;
+        break;
+    case INTERRUPT_SOURCE_TIMER_CMIA:
+        vector = VECTOR_INTERNAL_INTERRUPT_C0;
+        level  = (mcu.dev_register[DEV_IPRC] >> 0) & 7;
+        break;
+    case INTERRUPT_SOURCE_TIMER_CMIB:
+        vector = VECTOR_INTERNAL_INTERRUPT_C4;
+        level  = (mcu.dev_register[DEV_IPRC] >> 0) & 7;
+        break;
+    case INTERRUPT_SOURCE_TIMER_OVI:
+        vector = VECTOR_INTERNAL_INTERRUPT_C8;
+        level  = (mcu.dev_register[DEV_IPRC] >> 0) & 7;
+        break;
+    case INTERRUPT_SOURCE_ANALOG:
+        vector = VECTOR_INTERNAL_INTERRUPT_E0;
+        level  = (mcu.dev_register[DEV_IPRD] >> 0) & 7;
+        break;
+    case INTERRUPT_SOURCE_UART_RX:
+        vector = VECTOR_INTERNAL_INTERRUPT_D4;
+        level  = (mcu.dev_register[DEV_IPRD] >> 4) & 7;
+        break;
+    case INTERRUPT_SOURCE_UART_TX:
+        vector = VECTOR_INTERNAL_INTERRUPT_D8;
+        level  = (mcu.dev_register[DEV_IPRD] >> 4) & 7;
+        break;
+    default:
+        break;
+    }
 }
 
 void MCU_Interrupt_Handle(mcu_t& mcu)
@@ -97,15 +185,11 @@ void MCU_Interrupt_Handle(mcu_t& mcu)
         return;
     }
 #endif
-    uint32_t i;
-    for (i = 0; i < 16; i++)
+    if (auto it = mcu.trapa_pending.begin(); it != mcu.trapa_pending.end())
     {
-        if (mcu.trapa_pending[i])
-        {
-            mcu.trapa_pending[i] = 0;
-            MCU_Interrupt_StartVector(mcu, VECTOR_TRAPA_0 + i, -1);
-            return;
-        }
+        mcu.trapa_pending.Exclude(*it);
+        MCU_Interrupt_StartVector(mcu, VECTOR_TRAPA_0 + (*it), -1);
+        return;
     }
     if (mcu.exception_pending >= 0)
     {
@@ -122,104 +206,25 @@ void MCU_Interrupt_Handle(mcu_t& mcu)
                 break;
 
         }
-        mcu.exception_pending = -1;
+        mcu.exception_pending = (MCU_Exception_Source)-1;
         return;
     }
-    if (mcu.interrupt_pending[INTERRUPT_SOURCE_NMI])
+    if (mcu.interrupt_pending.Contains(INTERRUPT_SOURCE_NMI))
     {
         // mcu.interrupt_pending[INTERRUPT_SOURCE_NMI] = 0;
         MCU_Interrupt_StartVector(mcu, VECTOR_NMI, 7);
         return;
     }
     uint32_t mask = (mcu.sr >> 8) & 7;
-    for (i = INTERRUPT_SOURCE_NMI + 1; i < INTERRUPT_SOURCE_MAX; i++)
+    for (MCU_Interrupt_Source source : mcu.interrupt_pending)
     {
         int32_t vector = -1;
         int32_t level = 0;
-        if (!mcu.interrupt_pending[i])
-            continue;
-        switch (i)
-        {
-            case INTERRUPT_SOURCE_IRQ0:
-                if ((mcu.dev_register[DEV_P1CR] & 0x20) == 0)
-                    continue;
-                vector = VECTOR_IRQ0;
-                level = (mcu.dev_register[DEV_IPRA] >> 4) & 7;
-                break;
-            case INTERRUPT_SOURCE_IRQ1:
-                if ((mcu.dev_register[DEV_P1CR] & 0x40) == 0)
-                    continue;
-                vector = VECTOR_IRQ1;
-                level = (mcu.dev_register[DEV_IPRA] >> 0) & 7;
-                break;
-            case INTERRUPT_SOURCE_FRT0_OCIA:
-                vector = VECTOR_INTERNAL_INTERRUPT_94;
-                level = (mcu.dev_register[DEV_IPRB] >> 4) & 7;
-                break;
-            case INTERRUPT_SOURCE_FRT0_OCIB:
-                vector = VECTOR_INTERNAL_INTERRUPT_98;
-                level = (mcu.dev_register[DEV_IPRB] >> 4) & 7;
-                break;
-            case INTERRUPT_SOURCE_FRT0_FOVI:
-                vector = VECTOR_INTERNAL_INTERRUPT_9C;
-                level = (mcu.dev_register[DEV_IPRB] >> 4) & 7;
-                break;
-            case INTERRUPT_SOURCE_FRT1_OCIA:
-                vector = VECTOR_INTERNAL_INTERRUPT_A4;
-                level = (mcu.dev_register[DEV_IPRB] >> 0) & 7;
-                break;
-            case INTERRUPT_SOURCE_FRT1_OCIB:
-                vector = VECTOR_INTERNAL_INTERRUPT_A8;
-                level = (mcu.dev_register[DEV_IPRB] >> 0) & 7;
-                break;
-            case INTERRUPT_SOURCE_FRT1_FOVI:
-                vector = VECTOR_INTERNAL_INTERRUPT_AC;
-                level = (mcu.dev_register[DEV_IPRB] >> 0) & 7;
-                break;
-            case INTERRUPT_SOURCE_FRT2_OCIA:
-                vector = VECTOR_INTERNAL_INTERRUPT_B4;
-                level = (mcu.dev_register[DEV_IPRC] >> 4) & 7;
-                break;
-            case INTERRUPT_SOURCE_FRT2_OCIB:
-                vector = VECTOR_INTERNAL_INTERRUPT_B8;
-                level = (mcu.dev_register[DEV_IPRC] >> 4) & 7;
-                break;
-            case INTERRUPT_SOURCE_FRT2_FOVI:
-                vector = VECTOR_INTERNAL_INTERRUPT_BC;
-                level = (mcu.dev_register[DEV_IPRC] >> 4) & 7;
-                break;
-            case INTERRUPT_SOURCE_TIMER_CMIA:
-                vector = VECTOR_INTERNAL_INTERRUPT_C0;
-                level = (mcu.dev_register[DEV_IPRC] >> 0) & 7;
-                break;
-            case INTERRUPT_SOURCE_TIMER_CMIB:
-                vector = VECTOR_INTERNAL_INTERRUPT_C4;
-                level = (mcu.dev_register[DEV_IPRC] >> 0) & 7;
-                break;
-            case INTERRUPT_SOURCE_TIMER_OVI:
-                vector = VECTOR_INTERNAL_INTERRUPT_C8;
-                level = (mcu.dev_register[DEV_IPRC] >> 0) & 7;
-                break;
-            case INTERRUPT_SOURCE_ANALOG:
-                vector = VECTOR_INTERNAL_INTERRUPT_E0;
-                level = (mcu.dev_register[DEV_IPRD] >> 0) & 7;
-                break;
-            case INTERRUPT_SOURCE_UART_RX:
-                vector = VECTOR_INTERNAL_INTERRUPT_D4;
-                level = (mcu.dev_register[DEV_IPRD] >> 4) & 7;
-                break;
-            case INTERRUPT_SOURCE_UART_TX:
-                vector = VECTOR_INTERNAL_INTERRUPT_D8;
-                level = (mcu.dev_register[DEV_IPRD] >> 4) & 7;
-                break;
-            default:
-                break;
-        }
-
+        MCU_Interrupt_GetVL(mcu, source, vector, level);
         if ((int32_t)mask < level)
         {
             // mcu.interrupt_pending[INTERRUPT_SOURCE_NMI] = 0;
-            MCU_Interrupt_StartVector(mcu, vector, level);
+            MCU_Interrupt_StartVector(mcu, (uint32_t)vector, level);
             return;
         }
     }

--- a/src/nuked-sc55/backend/mcu_interrupt.h
+++ b/src/nuked-sc55/backend/mcu_interrupt.h
@@ -38,12 +38,7 @@
 
 struct mcu_t;
 
-void MCU_Interrupt_SetRequest(mcu_t& mcu, uint32_t interrupt, uint32_t value);
-void MCU_Interrupt_Exception(mcu_t& mcu, uint32_t exception);
-void MCU_Interrupt_TRAPA(mcu_t& mcu, uint32_t vector);
-void MCU_Interrupt_Handle(mcu_t& mcu);
-
-enum {
+enum MCU_Interrupt_Source : uint8_t {
     INTERRUPT_SOURCE_NMI = 0,
     INTERRUPT_SOURCE_IRQ0, // GPINT
     INTERRUPT_SOURCE_IRQ1,
@@ -68,8 +63,13 @@ enum {
     INTERRUPT_SOURCE_MAX
 };
 
-enum {
+enum MCU_Exception_Source : int8_t {
     EXCEPTION_SOURCE_ADDRESS_ERROR = 0,
     EXCEPTION_SOURCE_INVALID_INSTRUCTION,
     EXCEPTION_SOURCE_TRACE,
 };
+
+void MCU_Interrupt_SetRequest(mcu_t& mcu, MCU_Interrupt_Source interrupt, bool value);
+void MCU_Interrupt_Exception(mcu_t& mcu, MCU_Exception_Source exception);
+void MCU_Interrupt_TRAPA(mcu_t& mcu, uint8_t vector);
+void MCU_Interrupt_Handle(mcu_t& mcu);

--- a/src/nuked-sc55/backend/mcu_opcodes.cpp
+++ b/src/nuked-sc55/backend/mcu_opcodes.cpp
@@ -36,12 +36,15 @@
 #include "mcu.h"
 #include "mcu_interrupt.h"
 
-int32_t MCU_SUB_Common(mcu_t& mcu, int32_t t1, int32_t t2, int32_t c_bit, uint32_t siz)
+#include <utility>
+
+int32_t MCU_SUB_Common(mcu_t& mcu, int32_t t1, int32_t t2, int32_t c_bit, MCU_Operand_Size siz)
 {
     int32_t st1, st2;
-    int32_t N, Z, C, V = 0;
-    if (siz)
+    bool N, Z, C, V = false;
+    switch (siz)
     {
+    case MCU_Operand_Size::WORD:
         st1 = (int16_t)t1;
         st2 = (int16_t)t2;
         t1 = (uint16_t)t1;
@@ -58,9 +61,8 @@ int32_t MCU_SUB_Common(mcu_t& mcu, int32_t t1, int32_t t2, int32_t c_bit, uint32
         st1 -= c_bit;
         if (st1 < INT16_MIN || st1 > INT16_MAX)
             V = 1;
-    }
-    else
-    {
+        break;
+    case MCU_Operand_Size::BYTE:
         st1 = (int8_t)t1;
         st2 = (int8_t)t2;
         t1 = (uint8_t)t1;
@@ -77,6 +79,10 @@ int32_t MCU_SUB_Common(mcu_t& mcu, int32_t t1, int32_t t2, int32_t c_bit, uint32
         st1 -= c_bit;
         if (st1 < INT8_MIN || st1 > INT8_MAX)
             V = 1;
+        break;
+    default:
+        // reason: siz provided always valid
+        std::unreachable();
     }
     MCU_SetStatus(mcu, N, STATUS_N);
     MCU_SetStatus(mcu, Z, STATUS_Z);
@@ -86,12 +92,13 @@ int32_t MCU_SUB_Common(mcu_t& mcu, int32_t t1, int32_t t2, int32_t c_bit, uint32
     return t1;
 }
 
-int32_t MCU_ADD_Common(mcu_t& mcu, int32_t t1, int32_t t2, int32_t c_bit, uint32_t siz)
+int32_t MCU_ADD_Common(mcu_t& mcu, int32_t t1, int32_t t2, int32_t c_bit, MCU_Operand_Size siz)
 {
     int32_t st1, st2;
-    int32_t N, Z, C, V = 0;
-    if (siz)
+    bool N, Z, C, V = false;
+    switch (siz)
     {
+    case MCU_Operand_Size::WORD:
         st1 = (int16_t)t1;
         st2 = (int16_t)t2;
         t1 = (uint16_t)t1;
@@ -108,9 +115,8 @@ int32_t MCU_ADD_Common(mcu_t& mcu, int32_t t1, int32_t t2, int32_t c_bit, uint32
         st1 += c_bit;
         if (st1 < INT16_MIN || st1 > INT16_MAX)
             V = 1;
-    }
-    else
-    {
+        break;
+    case MCU_Operand_Size::BYTE:
         st1 = (int8_t)t1;
         st2 = (int8_t)t2;
         t1 = (uint8_t)t1;
@@ -127,6 +133,10 @@ int32_t MCU_ADD_Common(mcu_t& mcu, int32_t t1, int32_t t2, int32_t c_bit, uint32
         st1 += c_bit;
         if (st1 < INT8_MIN || st1 > INT8_MAX)
             V = 1;
+        break;
+    default:
+        // reason: siz provided always valid
+        std::unreachable();
     }
     MCU_SetStatus(mcu, N, STATUS_N);
     MCU_SetStatus(mcu, Z, STATUS_Z);
@@ -159,11 +169,6 @@ enum {
     GENERAL_INDIRECT,
     GENERAL_ABSOLUTE,
     GENERAL_IMMEDIATE
-};
-
-enum {
-    OPERAND_BYTE = 0,
-    OPERAND_WORD
 };
 
 enum {
@@ -228,7 +233,7 @@ void MCU_Jump_PJSR(mcu_t& mcu, uint8_t operand)
     (void)opc; // unused
     uint8_t page = MCU_ReadCodeAdvance(mcu);
     uint16_t address;
-    address = MCU_ReadCodeAdvance(mcu) << 8;
+    address = (uint16_t)(MCU_ReadCodeAdvance(mcu) << 8);
     address |= MCU_ReadCodeAdvance(mcu);
     MCU_PushStack(mcu, mcu.pc);
     MCU_PushStack(mcu, mcu.cp);
@@ -242,7 +247,7 @@ void MCU_Jump_JSR(mcu_t& mcu, uint8_t operand)
 {
     (void)operand;
     uint16_t address;
-    address = MCU_ReadCodeAdvance(mcu) << 8;
+    address = (uint16_t)(MCU_ReadCodeAdvance(mcu) << 8);
     address |= MCU_ReadCodeAdvance(mcu);
     MCU_PushStack(mcu, mcu.pc);
     mcu.pc = address;
@@ -261,16 +266,16 @@ void MCU_Jump_Bcc(mcu_t& mcu, uint8_t operand)
 {
     uint16_t disp;
     uint32_t cond;
-    uint32_t branch = 0;
-    uint32_t N, C, Z, V;
+    bool branch = false;
+    bool N, C, Z, V;
     if (operand & 0x10)
     {
-        disp = MCU_ReadCodeAdvance(mcu) << 8;
+        disp = (uint16_t)(MCU_ReadCodeAdvance(mcu) << 8);
         disp |= MCU_ReadCodeAdvance(mcu);
     }
     else
     {
-        disp = (int8_t)MCU_ReadCodeAdvance(mcu);
+        disp = (uint16_t)(int8_t)MCU_ReadCodeAdvance(mcu);
     }
     cond = operand & 0x0f;
 
@@ -350,7 +355,7 @@ void MCU_Jump_RTD(mcu_t& mcu, uint8_t operand)
 
     if (operand == 0x14)
     {
-        mcu.r[7] += imm;
+        mcu.r[7] = (uint16_t)(mcu.r[7] + imm);
         if (mcu.r[7] & 1)
             MCU_ErrorTrap(mcu);
     }
@@ -382,8 +387,8 @@ void MCU_Jump_JMP(mcu_t& mcu, uint8_t operand)
             MCU_PushStack(mcu, mcu.pc);
             MCU_PushStack(mcu, mcu.cp);
             opcode_l &= ~1;
-            mcu.cp = mcu.r[opcode_l] & 0xff;
-            mcu.pc = mcu.r[opcode_l + 1];
+            mcu.cp = (uint8_t)(mcu.r[opcode_l] & 0xff);
+            mcu.pc = (uint16_t)mcu.r[opcode_l + 1];
         }
         else if (opcode_h == 0x1a)
         {
@@ -406,7 +411,7 @@ void MCU_Jump_JMP(mcu_t& mcu, uint8_t operand)
         opcode >>= 3;
         if (opcode == 0x17)
         {
-            uint16_t disp = (int8_t)MCU_ReadCodeAdvance(mcu);
+            uint16_t disp = (uint16_t)(int8_t)MCU_ReadCodeAdvance(mcu);
             mcu.r[reg]--;
             if (mcu.r[reg] != 0xffff)
             {
@@ -420,8 +425,8 @@ void MCU_Jump_JMP(mcu_t& mcu, uint8_t operand)
     }
     else if (operand == 0x10)
     {
-        uint32_t addr;
-        addr = MCU_ReadCodeAdvance(mcu) << 8;
+        uint16_t addr;
+        addr = (uint16_t)(MCU_ReadCodeAdvance(mcu) << 8);
         addr |= MCU_ReadCodeAdvance(mcu);
         mcu.pc = addr;
     }
@@ -432,8 +437,8 @@ void MCU_Jump_JMP(mcu_t& mcu, uint8_t operand)
         opcode >>= 3;
         if (opcode == 0x17)
         {
-            uint16_t disp = (int8_t)MCU_ReadCodeAdvance(mcu);
-            uint32_t Z = (mcu.sr & STATUS_Z) != 0;
+            uint16_t disp = (uint16_t)(int8_t)MCU_ReadCodeAdvance(mcu);
+            const bool Z = (mcu.sr & STATUS_Z) != 0;
             if (Z)
             {
                 mcu.r[reg]--;
@@ -455,8 +460,8 @@ void MCU_Jump_JMP(mcu_t& mcu, uint8_t operand)
         opcode >>= 3;
         if (opcode == 0x17)
         {
-            uint16_t disp = (int8_t)MCU_ReadCodeAdvance(mcu);
-            uint32_t Z = (mcu.sr & STATUS_Z) != 0;
+            uint16_t disp = (uint16_t)(int8_t)MCU_ReadCodeAdvance(mcu);
+            const bool Z = (mcu.sr & STATUS_Z) != 0;
             if (!Z)
             {
                 mcu.r[reg]--;
@@ -482,11 +487,11 @@ void MCU_Jump_BSR(mcu_t& mcu, uint8_t operand)
     uint16_t disp;
     if (operand == 0x0e)
     {
-        disp = (int8_t)MCU_ReadCodeAdvance(mcu);
+        disp = (uint16_t)(int8_t)MCU_ReadCodeAdvance(mcu);
     }
     else
     {
-        disp = MCU_ReadCodeAdvance(mcu) << 8;
+        disp = (uint16_t)(MCU_ReadCodeAdvance(mcu) << 8);
         disp |= MCU_ReadCodeAdvance(mcu);
     }
     MCU_PushStack(mcu, mcu.pc);
@@ -499,7 +504,7 @@ void MCU_Jump_PJMP(mcu_t& mcu, uint8_t operand)
     uint8_t page;
     uint16_t address;
     page = MCU_ReadCodeAdvance(mcu);
-    address = MCU_ReadCodeAdvance(mcu) << 8;
+    address = (uint16_t)(MCU_ReadCodeAdvance(mcu) << 8);
     address |= MCU_ReadCodeAdvance(mcu);
     mcu.cp = page;
     mcu.pc = address;
@@ -510,20 +515,28 @@ uint32_t MCU_Operand_Read(mcu_t& mcu)
     switch (mcu.operand_type)
     {
     case GENERAL_DIRECT:
-        if (mcu.operand_size)
+        switch (mcu.operand_size)
+        {
+        case MCU_Operand_Size::WORD:
             return mcu.r[mcu.operand_reg];
-        return mcu.r[mcu.operand_reg] & 0xff;
+        case MCU_Operand_Size::BYTE:
+            return mcu.r[mcu.operand_reg] & 0xff;
+        }
+        break;
     case GENERAL_INDIRECT:
     case GENERAL_ABSOLUTE:
-        if (mcu.operand_size)
+        switch (mcu.operand_size)
         {
+        case MCU_Operand_Size::WORD:
             if (mcu.operand_ea & 1)
             {
                 MCU_Interrupt_Exception(mcu, EXCEPTION_SOURCE_ADDRESS_ERROR);
             }
             return MCU_Read16(mcu, MCU_GetAddress(mcu.operand_ep, mcu.operand_ea));
+        case MCU_Operand_Size::BYTE:
+            return MCU_Read(mcu, MCU_GetAddress(mcu.operand_ep, mcu.operand_ea));
         }
-        return MCU_Read(mcu, MCU_GetAddress(mcu.operand_ep, mcu.operand_ea));
+        break;
     case GENERAL_IMMEDIATE:
         return mcu.operand_data;
     }
@@ -535,26 +548,32 @@ void MCU_Operand_Write(mcu_t& mcu, uint32_t data)
     switch (mcu.operand_type)
     {
     case GENERAL_DIRECT:
-        if (mcu.operand_size)
-            mcu.r[mcu.operand_reg] = data;
-        else
+        switch (mcu.operand_size)
         {
+        case MCU_Operand_Size::WORD:
+            mcu.r[mcu.operand_reg] = (uint16_t)data;
+            break;
+        case MCU_Operand_Size::BYTE:
             mcu.r[mcu.operand_reg] &= ~0xff;
             mcu.r[mcu.operand_reg] |= data & 0xff;
+            break;
         }
         break;
     case GENERAL_INDIRECT:
     case GENERAL_ABSOLUTE:
-        if (mcu.operand_size)
+        switch (mcu.operand_size)
         {
+        case MCU_Operand_Size::WORD:
             if (mcu.operand_ea & 1)
             {
                 MCU_Interrupt_Exception(mcu, EXCEPTION_SOURCE_ADDRESS_ERROR);
             }
-            MCU_Write16(mcu, MCU_GetAddress(mcu.operand_ep, mcu.operand_ea), data);
+            MCU_Write16(mcu, MCU_GetAddress(mcu.operand_ep, mcu.operand_ea), (uint16_t)data);
+            break;
+        case MCU_Operand_Size::BYTE:
+            MCU_Write(mcu, MCU_GetAddress(mcu.operand_ep, mcu.operand_ea), (uint8_t)data);
+            break;
         }
-        else
-            MCU_Write(mcu, MCU_GetAddress(mcu.operand_ep, mcu.operand_ea), data);
         break;
     case GENERAL_IMMEDIATE:
         MCU_Interrupt_Exception(mcu, EXCEPTION_SOURCE_INVALID_INSTRUCTION);
@@ -569,19 +588,19 @@ void MCU_Operand_General(mcu_t& mcu, uint8_t operand)
     uint32_t increase = INCREASE_NONE;
     uint32_t absolute = 0;
     (void)absolute; // unused
-    uint32_t reg = 0;
-    uint32_t siz = OPERAND_BYTE;
-    uint32_t data = 0;
+    uint8_t reg = 0;
+    MCU_Operand_Size siz = MCU_Operand_Size::BYTE;
+    uint16_t data = 0;
     uint32_t addr = 0;
-    uint32_t addrpage = 0;
-    uint32_t ea = 0;
-    uint32_t ep = 0;
+    uint8_t addrpage = 0;
+    uint16_t ea = 0;
+    uint8_t ep = 0;
     uint8_t opcode;
     uint8_t opcode_reg;
     if (operand & 0x08)
-        siz = OPERAND_WORD;
+        siz = MCU_Operand_Size::WORD;
     else
-        siz = OPERAND_BYTE;
+        siz = MCU_Operand_Size::BYTE;
     reg = operand & 0x07;
     switch (operand & 0xf0)
     {
@@ -593,7 +612,7 @@ void MCU_Operand_General(mcu_t& mcu, uint8_t operand)
         break;
     case 0xe0:
         type = GENERAL_INDIRECT;
-        disp = (int8_t)MCU_ReadCodeAdvance(mcu);
+        disp = (uint32_t)(int8_t)MCU_ReadCodeAdvance(mcu);
         break;
     case 0xf0:
         type = GENERAL_INDIRECT;
@@ -613,7 +632,7 @@ void MCU_Operand_General(mcu_t& mcu, uint8_t operand)
         if (reg == 5)
         {
             type = GENERAL_ABSOLUTE;
-            addr = mcu.br << 8;
+            addr = (uint32_t)mcu.br << 8;
             addr |= MCU_ReadCodeAdvance(mcu);
             addrpage = 0;
         }
@@ -621,7 +640,7 @@ void MCU_Operand_General(mcu_t& mcu, uint8_t operand)
         {
             type = GENERAL_IMMEDIATE;
             data = MCU_ReadCodeAdvance(mcu);
-            if (siz)
+            if (siz == MCU_Operand_Size::WORD)
             {
                 data <<= 8;
                 data |= MCU_ReadCodeAdvance(mcu);
@@ -632,7 +651,7 @@ void MCU_Operand_General(mcu_t& mcu, uint8_t operand)
         if (reg == 5)
         {
             type = GENERAL_ABSOLUTE;
-            addr = MCU_ReadCodeAdvance(mcu) << 8;
+            addr = (uint32_t)MCU_ReadCodeAdvance(mcu) << 8;
             addr |= MCU_ReadCodeAdvance(mcu);
             addrpage = mcu.dp;
         }
@@ -642,7 +661,7 @@ void MCU_Operand_General(mcu_t& mcu, uint8_t operand)
     {
         if (increase == INCREASE_DECREASE)
         {
-            if (siz || reg == 7)
+            if (siz == MCU_Operand_Size::WORD || reg == 7)
             {
                 mcu.r[reg] -= 2;
             }
@@ -651,10 +670,10 @@ void MCU_Operand_General(mcu_t& mcu, uint8_t operand)
                 mcu.r[reg] -= 1;
             }
         }
-        ea = mcu.r[reg] + disp;
+        ea = (uint16_t)(mcu.r[reg] + disp);
         if (increase == INCREASE_INCREASE)
         {
-            if (siz || reg == 7)
+            if (siz == MCU_Operand_Size::WORD || reg == 7)
             {
                 mcu.r[reg] += 2;
             }
@@ -664,15 +683,13 @@ void MCU_Operand_General(mcu_t& mcu, uint8_t operand)
             }
         }
 
-        ea &= 0xffff;
-
-        ep = MCU_GetPageForRegister(mcu, reg) & 0xff;
+        ep = MCU_GetPageForRegister(mcu, reg);
     }
     else if (type == GENERAL_ABSOLUTE)
     {
-        ea = addr & 0xffff;
+        ea = (uint16_t)addr;
 
-        ep = addrpage & 0xff;
+        ep = addrpage;
     }
 
     opcode = MCU_ReadCodeAdvance(mcu);
@@ -695,16 +712,19 @@ void MCU_Operand_General(mcu_t& mcu, uint8_t operand)
     MCU_Opcode_Table[opcode](mcu, opcode, opcode_reg);
 }
 
-void MCU_SetStatusCommon(mcu_t& mcu, uint32_t val, uint32_t siz)
+void MCU_SetStatusCommon(mcu_t& mcu, uint32_t val, MCU_Operand_Size siz)
 {
-    if (siz)
+    switch (siz)
+    {
+    case MCU_Operand_Size::WORD:
         val &= 0xffff;
-    else
-        val &= 0xff;
-    if (siz)
         MCU_SetStatus(mcu, val & 0x8000, STATUS_N);
-    else
+        break;
+    case MCU_Operand_Size::BYTE:
+        val &= 0xff;
         MCU_SetStatus(mcu, val & 0x80, STATUS_N);
+        break;
+    }
     MCU_SetStatus(mcu, val == 0, STATUS_Z);
     MCU_SetStatus(mcu, 0, STATUS_V);
 }
@@ -721,26 +741,26 @@ void MCU_Opcode_Short_MOVE(mcu_t& mcu, uint8_t opcode)
     uint8_t data = MCU_ReadCodeAdvance(mcu);
     mcu.r[reg] &= ~0xff;
     mcu.r[reg] |= data;
-    MCU_SetStatusCommon(mcu, data, 0);
+    MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::BYTE);
 }
 
 void MCU_Opcode_Short_MOVI(mcu_t& mcu, uint8_t opcode)
 {
     uint32_t reg = opcode & 0x07;
     uint16_t data;
-    data = MCU_ReadCodeAdvance(mcu) << 8;
+    data = (uint16_t)(MCU_ReadCodeAdvance(mcu) << 8);
     data |= MCU_ReadCodeAdvance(mcu);
     mcu.r[reg] = data;
-    MCU_SetStatusCommon(mcu, data, 1);
+    MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::WORD);
 }
 
 void MCU_Opcode_Short_MOVF(mcu_t& mcu, uint8_t opcode)
 {
     uint32_t reg = opcode & 0x07;
     uint32_t siz = (opcode & 0x08) != 0;
-    int8_t disp = MCU_ReadCodeAdvance(mcu);
+    int8_t disp = (int8_t)MCU_ReadCodeAdvance(mcu);
     uint32_t addr = (mcu.r[6] + disp) & 0xffff;
-    addr |= mcu.tp << 16;
+    addr |= (uint32_t)(mcu.tp << 16);
     if ((opcode & 0x10) == 0)
     {
         uint16_t data;
@@ -749,13 +769,13 @@ void MCU_Opcode_Short_MOVF(mcu_t& mcu, uint8_t opcode)
             data = MCU_Read16(mcu, addr);
             mcu.r[reg] &= ~0xff;
             mcu.r[reg] |= data;
-            MCU_SetStatusCommon(mcu, data, 0);
+            MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::BYTE);
         }
         else
         {
             data = MCU_Read(mcu, addr);
             mcu.r[reg] = data;
-            MCU_SetStatusCommon(mcu, data, 1);
+            MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::WORD);
         }
     }
     else
@@ -764,14 +784,14 @@ void MCU_Opcode_Short_MOVF(mcu_t& mcu, uint8_t opcode)
         if (siz)
         {
             data = mcu.r[reg] & 0xff;
-            MCU_Write(mcu, addr, data);
-            MCU_SetStatusCommon(mcu, data, 0);
+            MCU_Write(mcu, addr, (uint8_t)data);
+            MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::BYTE);
         }
         else
         {
             data = mcu.r[reg];
             MCU_Write16(mcu, addr, data);
-            MCU_SetStatusCommon(mcu, data, 1);
+            MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::WORD);
         }
     }
 }
@@ -780,7 +800,7 @@ void MCU_Opcode_Short_MOVL(mcu_t& mcu, uint8_t opcode)
 {
     uint32_t reg = opcode & 0x07;
     uint32_t siz = (opcode & 0x08) != 0;
-    uint16_t addr = mcu.br << 8;
+    uint16_t addr = (uint16_t)(mcu.br << 8);
     uint32_t data;
     addr |= MCU_ReadCodeAdvance(mcu);
     if (siz)
@@ -788,15 +808,15 @@ void MCU_Opcode_Short_MOVL(mcu_t& mcu, uint8_t opcode)
         if (addr & 1)
             MCU_Interrupt_Exception(mcu, EXCEPTION_SOURCE_ADDRESS_ERROR);
         data = MCU_Read16(mcu, addr);
-        mcu.r[reg] = data;
-        MCU_SetStatusCommon(mcu, data, 1);
+        mcu.r[reg] = (uint16_t)data;
+        MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::WORD);
     }
     else
     {
         data = MCU_Read(mcu, addr);
         mcu.r[reg] &= ~0xff;
-        mcu.r[reg] |= data;
-        MCU_SetStatusCommon(mcu, data, 0);
+        mcu.r[reg] |= (uint16_t)data;
+        MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::BYTE);
     }
 }
 
@@ -804,8 +824,8 @@ void MCU_Opcode_Short_MOVS(mcu_t& mcu, uint8_t opcode)
 {
     uint32_t reg = opcode & 0x07;
     uint32_t siz = (opcode & 0x08) != 0;
-    uint16_t addr = mcu.br << 8;
-    uint32_t data;
+    uint16_t addr = (uint16_t)(mcu.br << 8);
+    uint16_t data;
     addr |= MCU_ReadCodeAdvance(mcu);
     if (siz)
     {
@@ -813,29 +833,33 @@ void MCU_Opcode_Short_MOVS(mcu_t& mcu, uint8_t opcode)
             MCU_Interrupt_Exception(mcu, EXCEPTION_SOURCE_ADDRESS_ERROR);
         data = mcu.r[reg];
         MCU_Write16(mcu, addr, data);
-        MCU_SetStatusCommon(mcu, data, 1);
+        MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::WORD);
     }
     else
     {
         data = mcu.r[reg] & 0xff;
-        MCU_Write(mcu, addr, data);
-        MCU_SetStatusCommon(mcu, data, 0);
+        MCU_Write(mcu, addr, (uint8_t)data);
+        MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::BYTE);
     }
 }
 
 void MCU_Opcode_Short_CMP(mcu_t& mcu, uint8_t opcode)
 {
     uint32_t reg = opcode & 0x07;
-    uint32_t siz = (opcode & 0x08) != 0;
+    const MCU_Operand_Size siz = (opcode & 0x08) ? MCU_Operand_Size::WORD : MCU_Operand_Size::BYTE;
     int32_t t1, t2;
-    if (siz)
+    switch (siz)
     {
+    case MCU_Operand_Size::WORD:
         t2 = MCU_ReadCodeAdvance(mcu) << 8;
         t2 |= MCU_ReadCodeAdvance(mcu);
-    }
-    else
-    {
+        break;
+    case MCU_Operand_Size::BYTE:
         t2 = MCU_ReadCodeAdvance(mcu);
+        break;
+    default:
+        // reason: initialized to one of the two values above
+        std::unreachable();
     }
     t1 = mcu.r[reg];
     MCU_SUB_Common(mcu, t1, t2, 0, siz);
@@ -854,44 +878,48 @@ void MCU_Opcode_MOVG_Immediate(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     uint32_t data;
     if (opcode_reg == 6 && (mcu.operand_type == GENERAL_INDIRECT || mcu.operand_type == GENERAL_ABSOLUTE))
     {
-        data = (int8_t)MCU_ReadCodeAdvance(mcu);
+        data = (uint32_t)(int8_t)MCU_ReadCodeAdvance(mcu);
         MCU_Operand_Write(mcu, data);
         MCU_SetStatusCommon(mcu, data, mcu.operand_size);
     }
     else if (opcode_reg == 7 && (mcu.operand_type == GENERAL_INDIRECT || mcu.operand_type == GENERAL_ABSOLUTE))
     {
-        data = MCU_ReadCodeAdvance(mcu) << 8;
+        data = (uint32_t)MCU_ReadCodeAdvance(mcu) << 8;
         data |= MCU_ReadCodeAdvance(mcu);
         MCU_Operand_Write(mcu, data);
         MCU_SetStatusCommon(mcu, data, mcu.operand_size);
     }
-    else if (opcode_reg == 4 && (mcu.operand_type == GENERAL_INDIRECT || mcu.operand_type == GENERAL_ABSOLUTE) && mcu.operand_size == OPERAND_BYTE)
+    else if (opcode_reg == 4 && (mcu.operand_type == GENERAL_INDIRECT || mcu.operand_type == GENERAL_ABSOLUTE) &&
+             mcu.operand_size == MCU_Operand_Size::BYTE)
     {
         uint32_t t1 = MCU_Operand_Read(mcu);
         uint32_t t2 = MCU_ReadCodeAdvance(mcu);
-        MCU_SUB_Common(mcu, t1, t2, 0, OPERAND_BYTE);
+        MCU_SUB_Common(mcu, (int32_t)t1, (int32_t)t2, 0, MCU_Operand_Size::BYTE);
     }
-    else if (opcode_reg == 4 && (mcu.operand_type == GENERAL_INDIRECT || mcu.operand_type == GENERAL_ABSOLUTE) && mcu.operand_size == OPERAND_WORD) // FIXME
+    else if (opcode_reg == 4 && (mcu.operand_type == GENERAL_INDIRECT || mcu.operand_type == GENERAL_ABSOLUTE) &&
+             mcu.operand_size == MCU_Operand_Size::WORD) // FIXME
     {
         uint32_t t1 = MCU_Operand_Read(mcu);
         uint32_t t2 = (uint16_t)((int8_t)MCU_ReadCodeAdvance(mcu));
-        MCU_SUB_Common(mcu, t1, t2, 0, OPERAND_WORD);
+        MCU_SUB_Common(mcu, (int32_t)t1, (int32_t)t2, 0, MCU_Operand_Size::WORD);
     }
-    else if (opcode_reg == 5 && (mcu.operand_type == GENERAL_INDIRECT || mcu.operand_type == GENERAL_ABSOLUTE) && mcu.operand_size == OPERAND_WORD)
+    else if (opcode_reg == 5 && (mcu.operand_type == GENERAL_INDIRECT || mcu.operand_type == GENERAL_ABSOLUTE) &&
+             mcu.operand_size == MCU_Operand_Size::WORD)
     {
         uint32_t t1, t2;
         t1 = MCU_Operand_Read(mcu);
-        t2 = MCU_ReadCodeAdvance(mcu) << 8;
+        t2 = (uint32_t)MCU_ReadCodeAdvance(mcu) << 8;
         t2 |= MCU_ReadCodeAdvance(mcu);
-        MCU_SUB_Common(mcu, t1, t2, 0, OPERAND_WORD);
+        MCU_SUB_Common(mcu, (int32_t)t1, (int32_t)t2, 0, MCU_Operand_Size::WORD);
     }
-    else if (opcode_reg == 5 && (mcu.operand_type == GENERAL_INDIRECT || mcu.operand_type == GENERAL_ABSOLUTE) && mcu.operand_size == OPERAND_BYTE) // FIXME
+    else if (opcode_reg == 5 && (mcu.operand_type == GENERAL_INDIRECT || mcu.operand_type == GENERAL_ABSOLUTE) &&
+             mcu.operand_size == MCU_Operand_Size::BYTE) // FIXME
     {
         uint32_t t1, t2;
         t1 = MCU_Operand_Read(mcu);
-        t2 = MCU_ReadCodeAdvance(mcu) << 8;
+        t2 = (uint32_t)MCU_ReadCodeAdvance(mcu) << 8;
         t2 |= MCU_ReadCodeAdvance(mcu);
-        MCU_SUB_Common(mcu, t1, t2, 0, OPERAND_BYTE);
+        MCU_SUB_Common(mcu, (int32_t)t1, (int32_t)t2, 0, MCU_Operand_Size::BYTE);
     }
     else
     {
@@ -981,23 +1009,23 @@ void MCU_Opcode_CLR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
         MCU_SetStatusCommon(mcu, data, mcu.operand_size);
         MCU_SetStatus(mcu, 0, STATUS_C);
     }
-    else if (opcode_reg == 2 && mcu.operand_type == GENERAL_DIRECT && mcu.operand_size == 0) // EXTU
+    else if (opcode_reg == 2 && mcu.operand_type == GENERAL_DIRECT && mcu.operand_size == MCU_Operand_Size::BYTE) // EXTU
     {
-        uint32_t data = (uint8_t)mcu.r[mcu.operand_reg];
+        uint16_t data = mcu.r[mcu.operand_reg] & 0xff;
         mcu.r[mcu.operand_reg] = data;
         MCU_SetStatus(mcu, 0, STATUS_N);
         MCU_SetStatus(mcu, data == 0, STATUS_Z);
         MCU_SetStatus(mcu, 0, STATUS_V);
         MCU_SetStatus(mcu, 0, STATUS_C);
     }
-    else if (opcode_reg == 0 && mcu.operand_type == GENERAL_DIRECT && mcu.operand_size == 0) // SWAP
+    else if (opcode_reg == 0 && mcu.operand_type == GENERAL_DIRECT && mcu.operand_size == MCU_Operand_Size::BYTE) // SWAP
     {
-        uint32_t data = mcu.r[mcu.operand_reg];
-        uint32_t data_h = data >> 8;
-        uint32_t data_l = data & 0xff;
-        data = (data_l << 8) | data_h;
+        uint16_t data = mcu.r[mcu.operand_reg];
+        uint8_t data_h = (uint8_t)(data >> 8);
+        uint8_t data_l = (uint8_t)(data & 0xff);
+        data = (uint16_t)((data_l << 8) | data_h);
         mcu.r[mcu.operand_reg] = data;
-        MCU_SetStatusCommon(mcu, data, OPERAND_WORD);
+        MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::WORD);
     }
     else if (opcode_reg == 5 && mcu.operand_type != GENERAL_IMMEDIATE) // NOT
     {
@@ -1009,14 +1037,14 @@ void MCU_Opcode_CLR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     else if (opcode_reg == 4 && mcu.operand_type != GENERAL_IMMEDIATE) // NEG
     {
         uint32_t data = MCU_Operand_Read(mcu);
-        data = MCU_SUB_Common(mcu, 0, data, 0, mcu.operand_size);
+        data = (uint32_t)MCU_SUB_Common(mcu, 0, (int32_t)data, 0, mcu.operand_size);
         MCU_Operand_Write(mcu, data);
     }
-    else if (opcode_reg == 1 && mcu.operand_type == GENERAL_DIRECT && mcu.operand_size == 0) // EXTS
+    else if (opcode_reg == 1 && mcu.operand_type == GENERAL_DIRECT && mcu.operand_size == MCU_Operand_Size::BYTE) // EXTS
     {
         uint32_t data = mcu.r[mcu.operand_reg];
-        mcu.r[mcu.operand_reg] = (int8_t)data;
-        MCU_SetStatusCommon(mcu, data, OPERAND_WORD);
+        mcu.r[mcu.operand_reg] = (uint16_t)(int8_t)data;
+        MCU_SetStatusCommon(mcu, data, MCU_Operand_Size::WORD);
     }
     else
     {
@@ -1044,7 +1072,7 @@ void MCU_Opcode_BSET(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     if (mcu.operand_type != GENERAL_IMMEDIATE)
     {
         uint32_t data = MCU_Operand_Read(mcu);
-        uint32_t bit = opcode_reg | ((opcode & 1) << 3);
+        uint32_t bit = (uint32_t)opcode_reg | (uint32_t)((opcode & 1) << 3);
         MCU_SetStatus(mcu, (data & (1 << bit)) == 0, STATUS_Z);
         data |= 1 << bit;
         MCU_Operand_Write(mcu, data);
@@ -1060,7 +1088,7 @@ void MCU_Opcode_BCLR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     if (mcu.operand_type != GENERAL_IMMEDIATE)
     {
         uint32_t data = MCU_Operand_Read(mcu);
-        uint32_t bit = opcode_reg | ((opcode & 1) << 3);
+        uint32_t bit = (uint32_t)opcode_reg | (uint32_t)((opcode & 1) << 3);
         MCU_SetStatus(mcu, (data & (1 << bit)) == 0, STATUS_Z);
         data &= ~(1 << bit);
         MCU_Operand_Write(mcu, data);
@@ -1093,16 +1121,18 @@ void MCU_Opcode_MOVG(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
         {
             if (mcu.operand_type == GENERAL_DIRECT) // XCH
             {
-                if (mcu.operand_size)
+                switch (mcu.operand_size)
                 {
-                    uint32_t r1 = mcu.r[opcode_reg];
-                    uint32_t r2 = mcu.r[mcu.operand_reg];
-                    mcu.r[opcode_reg] = r2;
+                case MCU_Operand_Size::WORD: {
+                    const uint16_t r1      = mcu.r[opcode_reg];
+                    const uint16_t r2      = mcu.r[mcu.operand_reg];
+                    mcu.r[opcode_reg]      = r2;
                     mcu.r[mcu.operand_reg] = r1;
+                    break;
                 }
-                else
-                {
+                case MCU_Operand_Size::BYTE:
                     MCU_ErrorTrap(mcu);
+                    break;
                 }
             }
             else
@@ -1115,12 +1145,15 @@ void MCU_Opcode_MOVG(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
         else
         {
             data = MCU_Operand_Read(mcu);
-            if (mcu.operand_size)
-                mcu.r[opcode_reg] = data;
-            else
+            switch (mcu.operand_size)
             {
+            case MCU_Operand_Size::WORD:
+                mcu.r[opcode_reg] = (uint16_t)data;
+                break;
+            case MCU_Operand_Size::BYTE:
                 mcu.r[opcode_reg] &= ~0xff;
                 mcu.r[opcode_reg] |= data & 0xff;
+                break;
             }
             MCU_SetStatusCommon(mcu, data, mcu.operand_size);
         }
@@ -1132,7 +1165,7 @@ void MCU_Opcode_BTSTI(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     if (mcu.operand_type != GENERAL_IMMEDIATE)
     {
         uint32_t data = MCU_Operand_Read(mcu);
-        uint32_t bit = opcode_reg | ((opcode & 1) << 3);
+        uint32_t bit = (uint32_t)opcode_reg | (uint32_t)((opcode & 1) << 3);
         MCU_SetStatus(mcu, (data & (1 << bit)) == 0, STATUS_Z);
     }
     else
@@ -1146,7 +1179,7 @@ void MCU_Opcode_BNOTI(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     if (mcu.operand_type != GENERAL_IMMEDIATE)
     {
         uint32_t data = MCU_Operand_Read(mcu);
-        uint32_t bit = opcode_reg | ((opcode & 1) << 3);
+        uint32_t bit = (uint32_t)opcode_reg | (uint32_t)((opcode & 1) << 3);
         MCU_SetStatus(mcu, (data & (1 << bit)) == 0, STATUS_Z);
         data ^= (1 << bit);
         MCU_Operand_Write(mcu, data);
@@ -1161,7 +1194,7 @@ void MCU_Opcode_OR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
 {
     (void)opcode;
     uint32_t data = MCU_Operand_Read(mcu);
-    mcu.r[opcode_reg] |= data;
+    mcu.r[opcode_reg] |= (uint16_t)data;
     MCU_SetStatusCommon(mcu, mcu.r[opcode_reg], mcu.operand_size);
 }
 
@@ -1169,14 +1202,14 @@ void MCU_Opcode_CMP(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
 {
     (void)opcode;
     int32_t t1 = mcu.r[opcode_reg];
-    int32_t t2 = MCU_Operand_Read(mcu);
+    int32_t t2 = (int32_t)MCU_Operand_Read(mcu);
     MCU_SUB_Common(mcu, t1, t2, 0, mcu.operand_size);
 }
 
 void MCU_Opcode_ADDQ(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
 {
     (void)opcode;
-    int32_t t1 = MCU_Operand_Read(mcu);
+    int32_t t1 = (int32_t)MCU_Operand_Read(mcu);
     int32_t t2 = 0;
     switch (opcode_reg)
     {
@@ -1197,21 +1230,24 @@ void MCU_Opcode_ADDQ(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
         break;
     }
     t1 = MCU_ADD_Common(mcu, t1, t2, 0, mcu.operand_size);
-    MCU_Operand_Write(mcu, t1);
+    MCU_Operand_Write(mcu, (uint32_t)t1);
 }
 
 void MCU_Opcode_ADD(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
 {
     (void)opcode;
     int32_t t1 = mcu.r[opcode_reg];
-    int32_t t2 = MCU_Operand_Read(mcu);
+    int32_t t2 = (int32_t)MCU_Operand_Read(mcu);
     t1 = MCU_ADD_Common(mcu, t1, t2, 0, mcu.operand_size);
-    if (mcu.operand_size)
-        mcu.r[opcode_reg] = t1;
-    else
+    switch (mcu.operand_size)
     {
+    case MCU_Operand_Size::WORD:
+        mcu.r[opcode_reg] = (uint16_t)t1;
+        break;
+    case MCU_Operand_Size::BYTE:
         mcu.r[opcode_reg] &= ~0xff;
         mcu.r[opcode_reg] |= t1 & 0xff;
+        break;
     }
 }
 
@@ -1219,14 +1255,17 @@ void MCU_Opcode_SUB(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
 {
     (void)opcode;
     int32_t t1 = mcu.r[opcode_reg];
-    int32_t t2 = MCU_Operand_Read(mcu);
+    int32_t t2 = (int32_t)MCU_Operand_Read(mcu);
     t1 = MCU_SUB_Common(mcu, t1, t2, 0, mcu.operand_size);
-    if (mcu.operand_size)
-        mcu.r[opcode_reg] = t1;
-    else
+    switch (mcu.operand_size)
     {
+    case MCU_Operand_Size::WORD:
+        mcu.r[opcode_reg] = (uint16_t)t1;
+        break;
+    case MCU_Operand_Size::BYTE:
         mcu.r[opcode_reg] &= ~0xff;
         mcu.r[opcode_reg] |= t1 & 0xff;
+        break;
     }
 }
 
@@ -1234,11 +1273,16 @@ void MCU_Opcode_SUBS(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
 {
     (void)opcode;
     int32_t t1 = mcu.r[opcode_reg];
-    int32_t t2 = MCU_Operand_Read(mcu);
-    if (mcu.operand_size)
-        mcu.r[opcode_reg] = t1 - t2;
-    else
-        mcu.r[opcode_reg] = t1 - (int8_t)t2;
+    int32_t t2 = (int32_t)MCU_Operand_Read(mcu);
+    switch (mcu.operand_size)
+    {
+    case MCU_Operand_Size::WORD:
+        mcu.r[opcode_reg] = (uint16_t)(t1 - t2);
+        break;
+    case MCU_Operand_Size::BYTE:
+        mcu.r[opcode_reg] = (uint16_t)(t1 - (int8_t)t2);
+        break;
+    }
 }
 
 void MCU_Opcode_AND(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
@@ -1246,12 +1290,15 @@ void MCU_Opcode_AND(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     (void)opcode;
     uint32_t data = mcu.r[opcode_reg];
     data &= MCU_Operand_Read(mcu);
-    if (mcu.operand_size)
-        mcu.r[opcode_reg] = data;
-    else
+    switch (mcu.operand_size)
     {
+    case MCU_Operand_Size::WORD:
+        mcu.r[opcode_reg] = (uint16_t)data;
+        break;
+    case MCU_Operand_Size::BYTE:
         mcu.r[opcode_reg] &= ~0xff;
         mcu.r[opcode_reg] |= data & 0xff;
+        break;
     }
     MCU_SetStatusCommon(mcu, mcu.r[opcode_reg], mcu.operand_size);
 }
@@ -1262,7 +1309,7 @@ void MCU_Opcode_SHLR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     if (opcode_reg == 0x03 && mcu.operand_type != GENERAL_IMMEDIATE) // SHLR
     {
         uint32_t data = MCU_Operand_Read(mcu);
-        uint32_t C = data & 1;
+        const bool C = data & 1;
         data >>= 1;
         MCU_Operand_Write(mcu, data);
         MCU_SetStatus(mcu, C, STATUS_C);
@@ -1271,11 +1318,19 @@ void MCU_Opcode_SHLR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     else if (opcode_reg == 0x02 && mcu.operand_type != GENERAL_IMMEDIATE) // SHLL
     {
         uint32_t data = MCU_Operand_Read(mcu);
-        uint32_t C;
-        if (mcu.operand_size)
+        bool C;
+        switch (mcu.operand_size)
+        {
+        case MCU_Operand_Size::WORD:
             C = (data & 0x8000) != 0;
-        else
+            break;
+        case MCU_Operand_Size::BYTE:
             C = (data & 0x80) != 0;
+            break;
+        default:
+            // reason: operand_size set to one of these values in decoder
+            std::unreachable();
+        }
         data <<= 1;
         MCU_Operand_Write(mcu, data);
         MCU_SetStatus(mcu, C, STATUS_C);
@@ -1285,11 +1340,19 @@ void MCU_Opcode_SHLR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     {
         uint32_t data = MCU_Operand_Read(mcu);
         uint32_t bit = (mcu.sr & STATUS_C) != 0;
-        uint32_t C;
-        if (mcu.operand_size)
+        bool C;
+        switch (mcu.operand_size)
+        {
+        case MCU_Operand_Size::WORD:
             C = (data & 0x8000) != 0;
-        else
+            break;
+        case MCU_Operand_Size::BYTE:
             C = (data & 0x80) != 0;
+            break;
+        default:
+            // reason: operand_size set to valid value in decoder
+            std::unreachable();
+        }
         data <<= 1;
         data |= bit;
         MCU_Operand_Write(mcu, data);
@@ -1299,13 +1362,21 @@ void MCU_Opcode_SHLR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     else if (opcode_reg == 0x04 && mcu.operand_type != GENERAL_IMMEDIATE) // ROTL
     {
         uint32_t data = MCU_Operand_Read(mcu);
-        uint32_t C;
-        if (mcu.operand_size)
+        bool C;
+        switch (mcu.operand_size)
+        {
+        case MCU_Operand_Size::WORD:
             C = (data & 0x8000) != 0;
-        else
+            break;
+        case MCU_Operand_Size::BYTE:
             C = (data & 0x80) != 0;
+            break;
+        default:
+            // reason: operand_size set to valid value in decoder
+            std::unreachable();
+        }
         data <<= 1;
-        data |= C;
+        data |= (uint32_t)C;
         MCU_Operand_Write(mcu, data);
         MCU_SetStatus(mcu, C, STATUS_C);
         MCU_SetStatusCommon(mcu, data, mcu.operand_size);
@@ -1313,11 +1384,19 @@ void MCU_Opcode_SHLR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     else if (opcode_reg == 0x00 && mcu.operand_type != GENERAL_IMMEDIATE) // SHAL
     {
         uint32_t data = MCU_Operand_Read(mcu);
-        uint32_t C;
-        if (mcu.operand_size)
+        bool C;
+        switch (mcu.operand_size)
+        {
+        case MCU_Operand_Size::WORD:
             C = (data & 0x8000) != 0;
-        else
+            break;
+        case MCU_Operand_Size::BYTE:
             C = (data & 0x80) != 0;
+            break;
+        default:
+            // reason: operand_size set to valid value in decoder
+            std::unreachable();
+        }
         data <<= 1;
         MCU_Operand_Write(mcu, data);
         MCU_SetStatus(mcu, C, STATUS_C);
@@ -1326,17 +1405,21 @@ void MCU_Opcode_SHLR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     else if (opcode_reg == 0x01 && mcu.operand_type != GENERAL_IMMEDIATE) // SHAR
     {
         uint32_t data = MCU_Operand_Read(mcu);
-        uint32_t C = data & 0x1;
+        const bool C = data & 0x1;
         uint32_t msb;
-        if (mcu.operand_size)
+        switch (mcu.operand_size)
         {
+        case MCU_Operand_Size::WORD:
             msb = data & 0x8000;
-            data &= 0x7fff;
-        }
-        else
-        {
+            data &= 0xffff;
+            break;
+        case MCU_Operand_Size::BYTE:
             msb = data & 0x80;
-            data &= 0x7f;
+            data &= 0xff;
+            break;
+        default:
+            // reason: operand_size always set to valid value in decoder
+            std::unreachable();
         }
         data >>= 1;
         data |= msb;
@@ -1347,12 +1430,17 @@ void MCU_Opcode_SHLR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     else if (opcode_reg == 0x05 && mcu.operand_type != GENERAL_IMMEDIATE) // ROTR
     {
         uint32_t data = MCU_Operand_Read(mcu);
-        uint32_t C = (data & 0x1) != 0;
+        const bool C = (data & 0x1) != 0;
         data >>= 1;
-        if (mcu.operand_size)
-            data |= C << 15;
-        else
-            data |= C << 7;
+        switch (mcu.operand_size)
+        {
+        case MCU_Operand_Size::WORD:
+            data |= (uint32_t)C << 15;
+            break;
+        case MCU_Operand_Size::BYTE:
+            data |= (uint32_t)C << 7;
+            break;
+        }
         MCU_Operand_Write(mcu, data);
         MCU_SetStatus(mcu, C, STATUS_C);
         MCU_SetStatusCommon(mcu, data, mcu.operand_size);
@@ -1368,23 +1456,34 @@ void MCU_Opcode_MULXU(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
     (void)opcode;
     uint32_t t1 = MCU_Operand_Read(mcu);
     uint32_t t2 = mcu.r[opcode_reg];
-    uint32_t N, Z;
-    if (!mcu.operand_size)
+    bool N, Z;
+    switch (mcu.operand_size)
+    {
+    case MCU_Operand_Size::BYTE:
         t2 &= 0xff;
+        break;
+    case MCU_Operand_Size::WORD:
+        // explicitly do nothing
+        break;
+    }
     t1 *= t2;
 
-    if (mcu.operand_size)
+    switch (mcu.operand_size)
     {
+    case MCU_Operand_Size::WORD:
         opcode_reg &= ~1;
-        mcu.r[opcode_reg | 0] = t1 >> 16;
-        mcu.r[opcode_reg | 1] = t1;
+        mcu.r[opcode_reg | 0] = (uint16_t)(t1 >> 16);
+        mcu.r[opcode_reg | 1] = (uint16_t)t1;
         N = (t1 & 0x80000000UL) != 0; // FIXME
-    }
-    else
-    {
+        break;
+    case MCU_Operand_Size::BYTE:
         t1 &= 0xffff;
-        mcu.r[opcode_reg] = t1;
+        mcu.r[opcode_reg] = (uint16_t)t1;
         N = (t1 & 0x8000UL) != 0; // FIXME
+        break;
+    default:
+        // reason: operand_size always set to a valid value in decoder
+        std::unreachable();
     }
     Z = t1 == 0;
     MCU_SetStatus(mcu, N, STATUS_N);
@@ -1410,10 +1509,11 @@ void MCU_Opcode_DIVXU(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
         return;
     }
 
-    if (mcu.operand_size)
+    switch (mcu.operand_size)
     {
+    case MCU_Operand_Size::WORD:
         opcode_reg &= ~1;
-        t2 = mcu.r[opcode_reg | 0] << 16;
+        t2 = (uint32_t)mcu.r[opcode_reg | 0] << 16;
         t2 |= mcu.r[opcode_reg | 1];
 
         R = t2 % t1;
@@ -1428,14 +1528,13 @@ void MCU_Opcode_DIVXU(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
         }
         else
         {
-            mcu.r[opcode_reg | 0] = R;
-            mcu.r[opcode_reg | 1] = Q;
-            MCU_SetStatusCommon(mcu, Q, OPERAND_WORD);
+            mcu.r[opcode_reg | 0] = (uint16_t)R;
+            mcu.r[opcode_reg | 1] = (uint16_t)Q;
+            MCU_SetStatusCommon(mcu, Q, MCU_Operand_Size::WORD);
             MCU_SetStatus(mcu, 0, STATUS_C);
         }
-    }
-    else
-    {
+        break;
+    case MCU_Operand_Size::BYTE:
         t2 = mcu.r[opcode_reg];
 
         R = t2 % t1;
@@ -1452,10 +1551,11 @@ void MCU_Opcode_DIVXU(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
         {
             R &= 0xff;
             Q &= 0xff;
-            mcu.r[opcode_reg] = (R << 8) | Q;
-            MCU_SetStatusCommon(mcu, Q, OPERAND_BYTE);
+            mcu.r[opcode_reg] = (uint16_t)((R << 8) | Q);
+            MCU_SetStatusCommon(mcu, Q, MCU_Operand_Size::BYTE);
             MCU_SetStatus(mcu, 0, STATUS_C);
         }
+        break;
     }
 }
 
@@ -1463,16 +1563,23 @@ void MCU_Opcode_ADDS(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
 {
     (void)opcode;
     uint32_t data = MCU_Operand_Read(mcu);
-    if (!mcu.operand_size)
-        data = (int8_t)data;
-    mcu.r[opcode_reg] += data;
+    switch (mcu.operand_size)
+    {
+    case MCU_Operand_Size::BYTE:
+        data = (uint32_t)(int8_t)data;
+        break;
+    case MCU_Operand_Size::WORD:
+        // explicitly do nothing
+        break;
+    }
+    mcu.r[opcode_reg] = (uint16_t)(mcu.r[opcode_reg] + data);
 }
 
 void MCU_Opcode_XOR(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
 {
     (void)opcode;
     uint32_t data = MCU_Operand_Read(mcu);
-    mcu.r[opcode_reg] ^= data;
+    mcu.r[opcode_reg] ^= (uint16_t)data;
     MCU_SetStatusCommon(mcu, mcu.r[opcode_reg], mcu.operand_size);
 }
 
@@ -1480,19 +1587,21 @@ void MCU_Opcode_ADDX(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
 {
     (void)opcode;
     int32_t t1 = mcu.r[opcode_reg];
-    int32_t t2 = MCU_Operand_Read(mcu);
-    int32_t C = (mcu.sr & STATUS_C) != 0;
-    int32_t Z = (mcu.sr & STATUS_Z) != 0;
+    int32_t t2 = (int32_t)MCU_Operand_Read(mcu);
+    const bool C = (mcu.sr & STATUS_C) != 0;
+    const bool Z = (mcu.sr & STATUS_Z) != 0;
     t1 = MCU_ADD_Common(mcu, t1, t2, C, mcu.operand_size);
     if (!Z)
         MCU_SetStatus(mcu, 0, STATUS_Z);
-
-    if (mcu.operand_size)
-        mcu.r[opcode_reg] = t1;
-    else
+    switch (mcu.operand_size)
     {
+    case MCU_Operand_Size::WORD:
+        mcu.r[opcode_reg] = (uint16_t)t1;
+        break;
+    case MCU_Operand_Size::BYTE:
         mcu.r[opcode_reg] &= ~0xff;
         mcu.r[opcode_reg] |= t1 & 0xff;
+        break;
     }
 }
 
@@ -1500,15 +1609,18 @@ void MCU_Opcode_SUBX(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg)
 {
     (void)opcode;
     int32_t t1 = mcu.r[opcode_reg];
-    int32_t t2 = MCU_Operand_Read(mcu);
-    int32_t C = (mcu.sr & STATUS_C) != 0;
+    int32_t t2 = (int32_t)MCU_Operand_Read(mcu);
+    const bool C = (mcu.sr & STATUS_C) != 0;
     t1 = MCU_SUB_Common(mcu, t1, t2, C, mcu.operand_size);
-    if (mcu.operand_size)
-        mcu.r[opcode_reg] = t1;
-    else
+    switch (mcu.operand_size)
     {
+    case MCU_Operand_Size::WORD:
+        mcu.r[opcode_reg] = (uint16_t)t1;
+        break;
+    case MCU_Operand_Size::BYTE:
         mcu.r[opcode_reg] &= ~0xff;
         mcu.r[opcode_reg] |= t1 & 0xff;
+        break;
     }
 }
 

--- a/src/nuked-sc55/backend/mcu_opcodes.h
+++ b/src/nuked-sc55/backend/mcu_opcodes.h
@@ -38,5 +38,11 @@
 
 struct mcu_t;
 
+enum class MCU_Operand_Size : uint8_t
+{
+    BYTE,
+    WORD
+};
+
 extern void (*MCU_Operand_Table[256])(mcu_t& mcu, uint8_t operand);
 extern void (*MCU_Opcode_Table[32])(mcu_t& mcu, uint8_t opcode, uint8_t opcode_reg);

--- a/src/nuked-sc55/backend/mcu_timer.cpp
+++ b/src/nuked-sc55/backend/mcu_timer.cpp
@@ -36,17 +36,67 @@
 #include "mcu.h"
 #include <cstdint>
 
-enum {
-    REG_TCR = 0x00,
-    REG_TCSR = 0x01,
-    REG_FRCH = 0x02,
-    REG_FRCL = 0x03,
+enum TMR_TCR_Bits : uint8_t
+{
+    TMR_TCR_CKS0  = 1 << 0, // Clock Select 0
+    TMR_TCR_CKS1  = 1 << 1, // Clock Select 1
+    TMR_TCR_CKS2  = 1 << 2, // Clock Select 2
+    TMR_TCR_CCLR0 = 1 << 3, // Counter Clear 0
+    TMR_TCR_CCLR1 = 1 << 4, // Counter Clear 1
+    TMR_TCR_OVIE  = 1 << 5, // Timer Overflow Interrupt Enable
+    TMR_TCR_CMIEA = 1 << 6, // Compare-match Interrupt Enable A
+    TMR_TCR_CMIEB = 1 << 7, // Compare-match Interrupt Enable B
+};
+
+enum TMR_TCSR_Bits : uint8_t
+{
+    TMR_TCSR_OS0  = 1 << 0, // Output Select 0
+    TMR_TCSR_OS1  = 1 << 1, // Output Select 1
+    TMR_TCSR_OS2  = 1 << 2, // Output Select 2
+    TMR_TCSR_OS3  = 1 << 3, // Output Select 3
+    TMR_TCSR_BIT4 = 1 << 4, // Reserved
+    TMR_TCSR_OVF  = 1 << 5, // Timer Overflow Flag
+    TMR_TCSR_CMFA = 1 << 6, // Compare-Match Flag A
+    TMR_TCSR_CMFB = 1 << 7, // Compare-Match Flag B
+};
+
+enum FRT_TCR_Bits : uint8_t
+{
+    FRT_TCR_CKS0  = 1 << 0, // Clock Select 0
+    FRT_TCR_CKS1  = 1 << 1, // Clock Select 1
+    FRT_TCR_OEA   = 1 << 2, // Output Enable A
+    FRT_TCR_OEB   = 1 << 3, // Output Enable B
+    FRT_TCR_OVIE  = 1 << 4, // Timer overflow Interrupt Enable
+    FRT_TCR_OCIEA = 1 << 5, // Output Compare Interrupt Enable A
+    FRT_TCR_OCIEB = 1 << 6, // Output Compare Interrupt Enable B
+    FRT_TCR_ICIE  = 1 << 7, // Input Capture Interrupt Enable
+};
+
+enum FRT_TCSR_Bits : uint8_t
+{
+    FRT_TCSR_CCLRA = 1 << 0, // Counter Clear A
+    FRT_TCSR_IEDG  = 1 << 1, // Input Edge Select
+    FRT_TCSR_OLVLA = 1 << 2, // Output Level A
+    FRT_TCSR_OLVLB = 1 << 3, // Output Level B
+    FRT_TCSR_OVF   = 1 << 4, // Timer Overflow Flag
+    FRT_TCSR_OCFA  = 1 << 5, // Output Compare Flag A
+    FRT_TCSR_OCFB  = 1 << 6, // Output Compare Flag B
+    FRT_TCSR_ICF   = 1 << 7, // Input Capture Flag
+};
+
+// Values are byte offsets from start of FRTs in memory (ffa0, ffb0, ffc0)
+enum FRT_Field_Offset : uint8_t
+{
+    REG_TCR   = 0x00,
+    REG_TCSR  = 0x01,
+    REG_FRCH  = 0x02,
+    REG_FRCL  = 0x03,
     REG_OCRAH = 0x04,
     REG_OCRAL = 0x05,
     REG_OCRBH = 0x06,
     REG_OCRBL = 0x07,
-    REG_ICRH = 0x08,
-    REG_ICRL = 0x09,
+    REG_ICRH  = 0x08,
+    REG_ICRL  = 0x09,
 };
 
 void TIMER_Init(mcu_timer_t& timer, mcu_t& mcu)
@@ -54,38 +104,63 @@ void TIMER_Init(mcu_timer_t& timer, mcu_t& mcu)
     timer.mcu = &mcu;
 }
 
+void TIMER_Reset(mcu_timer_t& timer)
+{
+    for (int i = 0; i < 3; ++i)
+    {
+        timer.frt[i] = {
+            .tcr       = 0,
+            .tcsr      = 0,
+            .frc       = 0,
+            .ocra      = 0xffff,
+            .ocrb      = 0xffff,
+            .icr       = 0,
+            .status_rd = 0,
+        };
+    }
+    timer.tmr = {
+        .tcr       = 0,
+        .tcsr      = TMR_TCSR_BIT4,
+        .tcora     = 0xff,
+        .tcorb     = 0xff,
+        .tcnt      = 0,
+        .status_rd = 0,
+    };
+}
+
 void TIMER_Write(mcu_timer_t& timer, uint32_t address, uint8_t data)
 {
     uint32_t t = (address >> 4) - 1;
     if (t > 2)
         return;
+    frt_t& frt = timer.frt[t];
+
     address &= 0x0f;
-    frt_t *ftimer = &timer.frt[t];
     switch (address)
     {
     case REG_TCR:
-        ftimer->tcr = data;
+        frt.tcr = data;
         break;
     case REG_TCSR:
-        ftimer->tcsr &= ~0xf;
-        ftimer->tcsr |= data & 0xf;
-        if ((data & 0x10) == 0 && (ftimer->status_rd & 0x10) != 0)
+        frt.tcsr &= ~0xf;
+        frt.tcsr |= data & 0xf;
+        if ((data & FRT_TCSR_OVF) == 0 && (frt.status_rd & FRT_TCSR_OVF) != 0)
         {
-            ftimer->tcsr &= ~0x10;
-            ftimer->status_rd &= ~0x10;
-            MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_FRT0_FOVI + t * 4, 0);
+            frt.tcsr      &= ~FRT_TCSR_OVF;
+            frt.status_rd &= ~FRT_TCSR_OVF;
+            MCU_Interrupt_SetRequest(*timer.mcu, (MCU_Interrupt_Source)(INTERRUPT_SOURCE_FRT0_FOVI + t * 4), 0);
         }
-        if ((data & 0x20) == 0 && (ftimer->status_rd & 0x20) != 0)
+        if ((data & FRT_TCSR_OCFA) == 0 && (frt.status_rd & FRT_TCSR_OCFA) != 0)
         {
-            ftimer->tcsr &= ~0x20;
-            ftimer->status_rd &= ~0x20;
-            MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_FRT0_OCIA + t * 4, 0);
+            frt.tcsr      &= ~FRT_TCSR_OCFA;
+            frt.status_rd &= ~FRT_TCSR_OCFA;
+            MCU_Interrupt_SetRequest(*timer.mcu, (MCU_Interrupt_Source)(INTERRUPT_SOURCE_FRT0_OCIA + t * 4), 0);
         }
-        if ((data & 0x40) == 0 && (ftimer->status_rd & 0x40) != 0)
+        if ((data & FRT_TCSR_OCFB) == 0 && (frt.status_rd & FRT_TCSR_OCFB) != 0)
         {
-            ftimer->tcsr &= ~0x40;
-            ftimer->status_rd &= ~0x40;
-            MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_FRT0_OCIB + t * 4, 0);
+            frt.tcsr      &= ~FRT_TCSR_OCFB;
+            frt.status_rd &= ~FRT_TCSR_OCFB;
+            MCU_Interrupt_SetRequest(*timer.mcu, (MCU_Interrupt_Source)(INTERRUPT_SOURCE_FRT0_OCIB + t * 4), 0);
         }
         break;
     case REG_FRCH:
@@ -95,16 +170,16 @@ void TIMER_Write(mcu_timer_t& timer, uint32_t address, uint8_t data)
         timer.tempreg = data;
         break;
     case REG_FRCL:
-        ftimer->frc = (timer.tempreg << 8) | data;
+        frt.frc = (uint16_t)((timer.tempreg << 8) | data);
         break;
     case REG_OCRAL:
-        ftimer->ocra = (timer.tempreg << 8) | data;
+        frt.ocra = (uint16_t)((timer.tempreg << 8) | data);
         break;
     case REG_OCRBL:
-        ftimer->ocrb = (timer.tempreg << 8) | data;
+        frt.ocrb = (uint16_t)((timer.tempreg << 8) | data);
         break;
     case REG_ICRL:
-        ftimer->icr = (timer.tempreg << 8) | data;
+        frt.icr = (uint16_t)((timer.tempreg << 8) | data);
         break;
     }
 }
@@ -114,31 +189,31 @@ uint8_t TIMER_Read(mcu_timer_t& timer, uint32_t address)
     uint32_t t = (address >> 4) - 1;
     if (t > 2)
         return 0xff;
+    frt_t& frt = timer.frt[t];
+
     address &= 0x0f;
-    frt_t *ftimer = &timer.frt[t];
     switch (address)
     {
     case REG_TCR:
-        return ftimer->tcr;
-    case REG_TCSR:
-    {
-        uint8_t ret = ftimer->tcsr;
-        ftimer->status_rd |= ftimer->tcsr & 0xf0;
-        //ftimer->status_rd |= 0xf0;
+        return frt.tcr;
+    case REG_TCSR: {
+        uint8_t ret    = frt.tcsr;
+        frt.status_rd |= frt.tcsr & 0xf0;
+        // frt.status_rd |= 0xf0;
         return ret;
     }
     case REG_FRCH:
-        timer.tempreg = ftimer->frc & 0xff;
-        return ftimer->frc >> 8;
+        timer.tempreg = (uint8_t)frt.frc;
+        return (uint8_t)(frt.frc >> 8);
     case REG_OCRAH:
-        timer.tempreg = ftimer->ocra & 0xff;
-        return ftimer->ocra >> 8;
+        timer.tempreg = (uint8_t)frt.ocra;
+        return (uint8_t)(frt.ocra >> 8);
     case REG_OCRBH:
-        timer.tempreg = ftimer->ocrb & 0xff;
-        return ftimer->ocrb >> 8;
+        timer.tempreg = (uint8_t)frt.ocrb;
+        return (uint8_t)(frt.ocrb >> 8);
     case REG_ICRH:
-        timer.tempreg = ftimer->icr & 0xff;
-        return ftimer->icr >> 8;
+        timer.tempreg = (uint8_t)frt.icr;
+        return (uint8_t)(frt.icr >> 8);
     case REG_FRCL:
     case REG_OCRAL:
     case REG_OCRBL:
@@ -150,157 +225,183 @@ uint8_t TIMER_Read(mcu_timer_t& timer, uint32_t address)
 
 void TIMER2_Write(mcu_timer_t& timer, uint32_t address, uint8_t data)
 {
+    tmr_t& tmr = timer.tmr;
+
     switch (address)
     {
     case DEV_TMR_TCR:
-        timer.tcr = data;
+        tmr.tcr = data;
         break;
     case DEV_TMR_TCSR:
-        timer.tcsr &= ~0xf;
-        timer.tcsr |= data & 0xf;
-        if ((data & 0x20) == 0 && (timer.status_rd & 0x20) != 0)
+        tmr.tcsr &= ~0xf;
+        tmr.tcsr |= data & 0xf;
+        if ((data & TMR_TCSR_OVF) == 0 && (tmr.status_rd & TMR_TCSR_OVF) != 0)
         {
-            timer.tcsr &= ~0x20;
-            timer.status_rd &= ~0x20;
+            tmr.tcsr      &= ~TMR_TCSR_OVF;
+            tmr.status_rd &= ~TMR_TCSR_OVF;
             MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_TIMER_OVI, 0);
         }
-        if ((data & 0x40) == 0 && (timer.status_rd & 0x40) != 0)
+        if ((data & TMR_TCSR_CMFA) == 0 && (tmr.status_rd & TMR_TCSR_CMFA) != 0)
         {
-            timer.tcsr &= ~0x40;
-            timer.status_rd &= ~0x40;
+            tmr.tcsr      &= ~TMR_TCSR_CMFA;
+            tmr.status_rd &= ~TMR_TCSR_CMFA;
             MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_TIMER_CMIA, 0);
         }
-        if ((data & 0x80) == 0 && (timer.status_rd & 0x80) != 0)
+        if ((data & TMR_TCSR_CMFB) == 0 && (tmr.status_rd & TMR_TCSR_CMFB) != 0)
         {
-            timer.tcsr &= ~0x80;
-            timer.status_rd &= ~0x80;
+            tmr.tcsr      &= ~TMR_TCSR_CMFB;
+            tmr.status_rd &= ~TMR_TCSR_CMFB;
             MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_TIMER_CMIB, 0);
         }
         break;
     case DEV_TMR_TCORA:
-        timer.tcora = data;
+        tmr.tcora = data;
         break;
     case DEV_TMR_TCORB:
-        timer.tcorb = data;
+        tmr.tcorb = data;
         break;
     case DEV_TMR_TCNT:
-        timer.tcnt = data;
+        tmr.tcnt = data;
         break;
     }
 }
+
 uint8_t TIMER_Read2(mcu_timer_t& timer, uint32_t address)
 {
+    tmr_t& tmr = timer.tmr;
+
     switch (address)
     {
     case DEV_TMR_TCR:
-        return timer.tcr;
-    case DEV_TMR_TCSR:
-    {
-        uint8_t ret = timer.tcsr;
-        timer.status_rd |= timer.tcsr & 0xe0;
+        return tmr.tcr;
+    case DEV_TMR_TCSR: {
+        uint8_t ret    = tmr.tcsr;
+        tmr.status_rd |= tmr.tcsr & (TMR_TCSR_OVF | TMR_TCSR_CMFA | TMR_TCSR_CMFB);
         return ret;
     }
     case DEV_TMR_TCORA:
-        return timer.tcora;
+        return tmr.tcora;
     case DEV_TMR_TCORB:
-        return timer.tcorb;
+        return tmr.tcorb;
     case DEV_TMR_TCNT:
-        return timer.tcnt;
+        return tmr.tcnt;
     }
     return 0xff;
 }
 
-constexpr uint64_t FRT_STEP_TABLE_GENERIC[4] = {
-    3, 7, 31, 1
-};
+inline void TIMER_ClockFrt(mcu_timer_t& timer, int frt_id)
+{
+    frt_t& frt = timer.frt[frt_id];
 
-constexpr uint64_t FRT_STEP_TABLE_MK1[4] = {
-    3, 7, 31, 3
-};
+    if (timer.cycles & timer.frt_step_table[frt.tcr & (FRT_TCR_CKS0 | FRT_TCR_CKS1)])
+    {
+        return;
+    }
 
-constexpr uint64_t TIMER_STEP_TABLE_GENERIC[8] = {
-    0, 7, 63, 1023, 0, 1, 1, 1
-};
+    const bool matcha = frt.frc == frt.ocra;
+    const bool matchb = frt.frc == frt.ocrb;
+    if ((frt.tcsr & FRT_TCSR_CCLRA) && matcha) // CCLRA
+    {
+        frt.frc = 0;
+    }
+    else
+    {
+        ++frt.frc;
+        if (frt.frc == 0)
+        {
+            frt.tcsr |= FRT_TCSR_OVF;
+        }
+    }
 
-constexpr uint64_t TIMER_STEP_TABLE_MK1[8] = {
-    0, 7, 63, 1023, 0, 3, 3, 3
-};
+    // flags
+    if (matcha)
+        frt.tcsr |= FRT_TCSR_OCFA;
+    if (matchb)
+        frt.tcsr |= FRT_TCSR_OCFB;
+
+    if ((frt.tcr & FRT_TCR_OVIE) != 0 && (frt.tcsr & FRT_TCSR_OVF) != 0)
+        MCU_Interrupt_SetRequest(*timer.mcu, (MCU_Interrupt_Source)(INTERRUPT_SOURCE_FRT0_FOVI + frt_id * 4), 1);
+    if ((frt.tcr & FRT_TCR_OCIEA) != 0 && (frt.tcsr & FRT_TCSR_OCFA) != 0)
+        MCU_Interrupt_SetRequest(*timer.mcu, (MCU_Interrupt_Source)(INTERRUPT_SOURCE_FRT0_OCIA + frt_id * 4), 1);
+    if ((frt.tcr & FRT_TCR_OCIEB) != 0 && (frt.tcsr & FRT_TCSR_OCFB) != 0)
+        MCU_Interrupt_SetRequest(*timer.mcu, (MCU_Interrupt_Source)(INTERRUPT_SOURCE_FRT0_OCIB + frt_id * 4), 1);
+}
+
+inline void TIMER_ClockTmr(mcu_timer_t& timer)
+{
+    tmr_t& tmr = timer.tmr;
+
+    const uint16_t step_mask = timer.tmr_step_table[tmr.tcr & (TMR_TCR_CKS0 | TMR_TCR_CKS1 | TMR_TCR_CKS2)];
+
+    if (step_mask == 0)
+    {
+        return;
+    }
+
+    if (timer.cycles & step_mask)
+    {
+        return;
+    }
+
+    const bool matcha = tmr.tcnt == tmr.tcora;
+    const bool matchb = tmr.tcnt == tmr.tcorb;
+    if ((tmr.tcr & (TMR_TCR_CCLR0 | TMR_TCR_CCLR1)) == TMR_TCR_CCLR0 && matcha)
+    {
+        tmr.tcnt = 0;
+    }
+    else if ((tmr.tcr & (TMR_TCR_CCLR0 | TMR_TCR_CCLR1)) == TMR_TCR_CCLR1 && matchb)
+    {
+        tmr.tcnt = 0;
+    }
+    else
+    {
+        ++tmr.tcnt;
+        if (tmr.tcnt == 0)
+        {
+            tmr.tcsr |= TMR_TCSR_OVF;
+        }
+    }
+
+    // flags
+    if (matcha)
+        tmr.tcsr |= TMR_TCSR_CMFA;
+    if (matchb)
+        tmr.tcsr |= TMR_TCSR_CMFB;
+
+    if ((tmr.tcr & TMR_TCR_OVIE) != 0 && (tmr.tcsr & TMR_TCSR_OVF) != 0)
+        MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_TIMER_OVI, 1);
+    if ((tmr.tcr & TMR_TCR_CMIEA) != 0 && (tmr.tcsr & TMR_TCSR_CMFA) != 0)
+        MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_TIMER_CMIA, 1);
+    if ((tmr.tcr & TMR_TCR_CMIEB) != 0 && (tmr.tcsr & TMR_TCSR_CMFB) != 0)
+        MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_TIMER_CMIB, 1);
+}
 
 void TIMER_Clock(mcu_timer_t& timer, uint64_t cycles)
 {
-    const bool mk1 = timer.mcu->is_mk1;
-    const auto& FRT_STEP_TABLE = mk1 ? FRT_STEP_TABLE_MK1 : FRT_STEP_TABLE_GENERIC;
-    const auto& TIMER_STEP_TABLE = mk1 ? TIMER_STEP_TABLE_MK1 : TIMER_STEP_TABLE_GENERIC;
-
-    while (timer.cycles*2 < cycles) // FIXME
+    while (timer.cycles * 2 < cycles) // FIXME
     {
         for (int i = 0; i < 3; i++)
         {
-            frt_t *ftimer = &timer.frt[i];
-
-            const bool frt_step = !(timer.cycles & FRT_STEP_TABLE[ftimer->tcr & 3]);
-
-            if (frt_step)
-            {
-                uint32_t value = ftimer->frc;
-                uint32_t matcha = value == ftimer->ocra;
-                uint32_t matchb = value == ftimer->ocrb;
-                if ((ftimer->tcsr & 1) != 0 && matcha) // CCLRA
-                    value = 0;
-                else
-                    value++;
-                uint32_t of = (value >> 16) & 1;
-                value &= 0xffff;
-                ftimer->frc = value;
-
-                // flags
-                if (of)
-                    ftimer->tcsr |= 0x10;
-                if (matcha)
-                    ftimer->tcsr |= 0x20;
-                if (matchb)
-                    ftimer->tcsr |= 0x40;
-                if ((ftimer->tcr & 0x10) != 0 && (ftimer->tcsr & 0x10) != 0)
-                    MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_FRT0_FOVI + i * 4, 1);
-                if ((ftimer->tcr & 0x20) != 0 && (ftimer->tcsr & 0x20) != 0)
-                    MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_FRT0_OCIA + i * 4, 1);
-                if ((ftimer->tcr & 0x40) != 0 && (ftimer->tcsr & 0x40) != 0)
-                    MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_FRT0_OCIB + i * 4, 1);
-            }
+            TIMER_ClockFrt(timer, i);
         }
 
-        const bool timer_step = !(timer.cycles & TIMER_STEP_TABLE[timer.tcr & 7]);
+        TIMER_ClockTmr(timer);
 
-        if (timer_step)
-        {
-            uint32_t value = timer.tcnt;
-            uint32_t matcha = value == timer.tcora;
-            uint32_t matchb = value == timer.tcorb;
-            if ((timer.tcr & 24) == 8 && matcha)
-                value = 0;
-            else if ((timer.tcr & 24) == 16 && matchb)
-                value = 0;
-            else
-                value++;
-            uint32_t of = (value >> 8) & 1;
-            value &= 0xff;
-            timer.tcnt = value;
-
-            // flags
-            if (of)
-                timer.tcsr |= 0x20;
-            if (matcha)
-                timer.tcsr |= 0x40;
-            if (matchb)
-                timer.tcsr |= 0x80;
-            if ((timer.tcr & 0x20) != 0 && (timer.tcsr & 0x20) != 0)
-                MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_TIMER_OVI, 1);
-            if ((timer.tcr & 0x40) != 0 && (timer.tcsr & 0x40) != 0)
-                MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_TIMER_CMIA, 1);
-            if ((timer.tcr & 0x80) != 0 && (timer.tcsr & 0x80) != 0)
-                MCU_Interrupt_SetRequest(*timer.mcu, INTERRUPT_SOURCE_TIMER_CMIB, 1);
-        }
-
-        timer.cycles++;
+        ++timer.cycles;
     }
+}
+
+// These tables are indexed by the low CKSn bits of the TCR.
+constexpr FRT_Step_Table FRT_STEP_TABLE_GENERIC = {3, 7, 31, 1};
+constexpr FRT_Step_Table FRT_STEP_TABLE_MK1     = {3, 7, 31, 3};
+
+// A value of 0 means do not step.
+constexpr TMR_Step_Table TMR_STEP_TABLE_GENERIC = {0, 7, 63, 1023, 0, 1, 1, 1};
+constexpr TMR_Step_Table TMR_STEP_TABLE_MK1     = {0, 7, 63, 1023, 0, 3, 3, 3};
+
+void TIMER_NotifyRomsetChange(mcu_timer_t& timer)
+{
+    const bool is_mk1    = timer.mcu->is_mk1;
+    timer.frt_step_table = is_mk1 ? FRT_STEP_TABLE_MK1 : FRT_STEP_TABLE_GENERIC;
+    timer.tmr_step_table = is_mk1 ? TMR_STEP_TABLE_MK1 : TMR_STEP_TABLE_GENERIC;
 }

--- a/src/nuked-sc55/backend/mcu_timer.h
+++ b/src/nuked-sc55/backend/mcu_timer.h
@@ -34,40 +34,61 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 
 struct mcu_t;
 
-struct frt_t {
-    uint8_t tcr = 0;
-    uint8_t tcsr = 0;
-    uint16_t frc = 0;
-    uint16_t ocra = 0;
-    uint16_t ocrb = 0;
-    uint16_t icr = 0;
+using FRT_Step_Table = std::array<uint8_t, 4>;
+using TMR_Step_Table = std::array<uint16_t, 8>;
+
+// 16-bit free running timers
+struct frt_t
+{
+    uint8_t  tcr       = 0;
+    uint8_t  tcsr      = 0;
+    uint16_t frc       = 0;
+    uint16_t ocra      = 0;
+    uint16_t ocrb      = 0;
+    uint16_t icr       = 0;
+    uint8_t  status_rd = 0; // not an actual FRT register
+};
+
+// 8-bit timer
+struct tmr_t
+{
+    uint8_t tcr       = 0;
+    uint8_t tcsr      = 0;
+    uint8_t tcora     = 0;
+    uint8_t tcorb     = 0;
+    uint8_t tcnt      = 0;
     uint8_t status_rd = 0;
 };
 
-struct mcu_timer_t {
-    uint8_t tcr = 0;
-    uint8_t tcsr = 0;
-    uint8_t tcora = 0;
-    uint8_t tcorb = 0;
-    uint8_t tcnt = 0;
-    uint8_t status_rd = 0;
+struct mcu_timer_t
+{
+    uint64_t cycles = 0;
+    FRT_Step_Table frt_step_table;
+    TMR_Step_Table tmr_step_table;
 
     mcu_t* mcu = nullptr;
-
-    uint64_t cycles = 0;
+    frt_t   frt[3]{};
+    tmr_t   tmr{};
     uint8_t tempreg = 0;
-
-    frt_t frt[3]{};
 };
 
 void TIMER_Init(mcu_timer_t& timer, mcu_t& mcu);
+void TIMER_Reset(mcu_timer_t& timer);
+
+// Read/write 16-bit FRTs
 void TIMER_Write(mcu_timer_t& timer, uint32_t address, uint8_t data);
 uint8_t TIMER_Read(mcu_timer_t& timer, uint32_t address);
-void TIMER_Clock(mcu_timer_t& timer, uint64_t cycles);
 
+// Read/write 8-bit timer
 void TIMER2_Write(mcu_timer_t& timer, uint32_t address, uint8_t data);
 uint8_t TIMER_Read2(mcu_timer_t& timer, uint32_t address);
+
+// Update all timers and trigger interrupts
+void TIMER_Clock(mcu_timer_t& timer, uint64_t cycles);
+
+void TIMER_NotifyRomsetChange(mcu_timer_t& timer);

--- a/src/nuked-sc55/backend/pcm.cpp
+++ b/src/nuked-sc55/backend/pcm.cpp
@@ -67,7 +67,8 @@ uint8_t PCM_ReadROM(pcm_t& pcm, uint32_t address)
         case 5:
         case 6:
             if (pcm.mcu->is_jv880)
-                return pcm.waverom_exp[(address & 0x1fffff) + (bank - 3) * 0x200000];
+                return pcm.waverom_exp[(address & 0x1fffff) + (uint32_t)((bank - 3) * 0x200000)];
+            [[fallthrough]];
         default:
             break;
     }
@@ -82,39 +83,39 @@ void PCM_Write(pcm_t& pcm, uint32_t address, uint8_t data)
         switch (address & 3)
         {
             case 0:
-                pcm.voice_mask_pending &= ~0xf000000;
-                pcm.voice_mask_pending |= (data & 0xf) << 24;
+                pcm.voice_mask_pending &= ~0xf000000u;
+                pcm.voice_mask_pending |= (uint32_t)(data & 0xf) << 24;
                 break;
             case 1:
-                pcm.voice_mask_pending &= ~0xff0000;
-                pcm.voice_mask_pending |= (data & 0xff) << 16;
+                pcm.voice_mask_pending &= ~0xff0000u;
+                pcm.voice_mask_pending |= (uint32_t)(data & 0xff) << 16;
                 break;
             case 2:
-                pcm.voice_mask_pending &= ~0xff00;
-                pcm.voice_mask_pending |= (data & 0xff) << 8;
+                pcm.voice_mask_pending &= ~0xff00u;
+                pcm.voice_mask_pending |= (uint32_t)(data & 0xff) << 8;
                 break;
             case 3:
-                pcm.voice_mask_pending &= ~0xff;
-                pcm.voice_mask_pending |= (data & 0xff) << 0;
+                pcm.voice_mask_pending &= ~0xffu;
+                pcm.voice_mask_pending |= (uint32_t)(data & 0xff) << 0;
                 break;
         }
-        pcm.voice_mask_updating = 1;
+        pcm.voice_mask_updating = true;
     }
     else if (address >= 0x20 && address < 0x24) // wave rom
     {
         switch (address & 3)
         {
             case 1:
-                pcm.wave_read_address &= ~0xff0000;
-                pcm.wave_read_address |= (data & 0xff) << 16;
+                pcm.wave_read_address &= ~0xff0000u;
+                pcm.wave_read_address |= (uint32_t)(data & 0xff) << 16;
                 break;
             case 2:
-                pcm.wave_read_address &= ~0xff00;
-                pcm.wave_read_address |= (data & 0xff) << 8;
+                pcm.wave_read_address &= ~0xff00u;
+                pcm.wave_read_address |= (uint32_t)(data & 0xff) << 8;
                 break;
             case 3:
-                pcm.wave_read_address &= ~0xff;
-                pcm.wave_read_address |= (data & 0xff) << 0;
+                pcm.wave_read_address &= ~0xffu;
+                pcm.wave_read_address |= (uint32_t)(data & 0xff) << 0;
                 pcm.wave_byte_latch = PCM_ReadROM(pcm, pcm.wave_read_address);
                 break;
         }
@@ -138,16 +139,16 @@ void PCM_Write(pcm_t& pcm, uint32_t address, uint8_t data)
         switch (address & 3)
         {
             case 1:
-                pcm.write_latch &= ~0xf0000;
-                pcm.write_latch |= (data & 0xf) << 16;
+                pcm.write_latch &= ~0xf0000u;
+                pcm.write_latch |= (uint32_t)(data & 0xf) << 16;
                 break;
             case 2:
-                pcm.write_latch &= ~0xff00;
-                pcm.write_latch |= (data & 0xff) << 8;
+                pcm.write_latch &= ~0xff00u;
+                pcm.write_latch |= (uint32_t)(data & 0xff) << 8;
                 break;
             case 3:
-                pcm.write_latch &= ~0xff;
-                pcm.write_latch |= (data & 0xff) << 0;
+                pcm.write_latch &= ~0xffu;
+                pcm.write_latch |= (uint32_t)(data & 0xff) << 0;
                 break;
         }
         if ((address & 3) == 3)
@@ -168,12 +169,12 @@ void PCM_Write(pcm_t& pcm, uint32_t address, uint8_t data)
         switch (address & 1)
         {
         case 0:
-            pcm.write_latch &= ~0xff00;
-            pcm.write_latch |= (data & 0xff) << 8;
+            pcm.write_latch &= ~0xff00u;
+            pcm.write_latch |= (uint32_t)(data & 0xff) << 8;
             break;
         case 1:
-            pcm.write_latch &= ~0xff;
-            pcm.write_latch |= (data & 0xff) << 0;
+            pcm.write_latch &= ~0xffu;
+            pcm.write_latch |= (uint32_t)(data & 0xff) << 0;
             break;
         }
         if ((address & 1) == 1)
@@ -182,7 +183,7 @@ void PCM_Write(pcm_t& pcm, uint32_t address, uint8_t data)
             if (address & 32)
                 ix |= 8;
 
-            pcm.ram2[pcm.select_channel][ix] = pcm.write_latch;
+            pcm.ram2[pcm.select_channel][ix] = static_cast<uint16_t>(pcm.write_latch);
         }
     }
 }
@@ -199,14 +200,14 @@ uint8_t PCM_Read(pcm_t& pcm, uint32_t address)
     {
         if (pcm.voice_mask_updating)
             pcm.voice_mask = pcm.voice_mask_pending;
-        pcm.voice_mask_updating = 0;
+        pcm.voice_mask_updating = false;
     }
     else if (address == 0x3c || address == 0x3e) // status
     {
         uint8_t status = 0;
         if (address == 0x3e && pcm.irq_assert)
         {
-            pcm.irq_assert = 0;
+            pcm.irq_assert = false;
             if (pcm.mcu->is_jv880)
                 MCU_GA_SetGAInt(*pcm.mcu, 5, 0);
             else
@@ -329,20 +330,18 @@ inline void calc_tv(pcm_t& pcm, int e, int adjust, uint16_t *levelcur, int activ
     int speed = adjust & 0xff;
     int target = (adjust >> 8) & 0xff;
 
-
-    int w1 = (speed & 0xf0) == 0;
-    int w2 = w1 || (speed & 0x10) != 0;
-    int w3 = pcm.nfs &&
+    const bool w1 = (speed & 0xf0) == 0;
+    const bool w2 = w1 || (speed & 0x10) != 0;
+    const bool w3 = pcm.nfs &&
         ((speed & 0x80) == 0 || ((speed & 0x40) == 0 && (!w2 || (speed & 0x20) == 0)));
 
-    int type = w2 | (w3 << 3);
+    int type = (int)w2 | ((int)w3 << 3);
     if (speed & 0x20)
         type |= 2;
     if ((speed & 0x80) == 0 || (speed & 0x40) == 0)
         type |= 4;
 
-
-    int write = !active;
+    bool write = !active;
     int addlow = 0;
     if (type & 4)
     {
@@ -415,7 +414,7 @@ inline void calc_tv(pcm_t& pcm, int e, int adjust, uint16_t *levelcur, int activ
         int sum1 = (target << 11); // 5
         if (e != 2 || active)
             sum1 -= (*levelcur << 4); // 6
-        int neg = (sum1 & 0x80000) != 0;
+        const bool neg = (sum1 & 0x80000) != 0;
         (void)neg; // unused
 
         int preshift = sum1;
@@ -439,13 +438,13 @@ inline void calc_tv(pcm_t& pcm, int e, int adjust, uint16_t *levelcur, int activ
     else
     {
         int shift = (speed >> 4) & 14;
-        shift |= w2;
+        shift |= (int)w2;
         shift = (10 - shift) & 15;
 
         int sum1 = target << 11; // 5
         if (e != 2 || active)
             sum1 -= (*levelcur << 4); // 6
-        int neg = (sum1 & 0x80000) != 0;
+        const bool neg = (sum1 & 0x80000) != 0;
         int preshift = (speed & 15) << 9;
         if (!w1)
             preshift |= 0x2000;
@@ -461,15 +460,15 @@ inline void calc_tv(pcm_t& pcm, int e, int adjust, uint16_t *levelcur, int activ
 
         int sum3 = (target << 11) - (sum2_l << 4);
 
-        int neg2 = (sum3 & 0x80000) != 0;
-        int xnor = !(neg2 ^ neg);
+        const bool neg2 = (sum3 & 0x80000) != 0;
+        const bool xnor = !(neg2 ^ neg);
 
         if (write && pcm.nfs)
         {
             if (xnor)
                 *levelcur = sum2_l & 0x7fff;
             else
-                *levelcur = target << 7;
+                *levelcur = (uint16_t)(target << 7);
         }
 
         if (e == 0)
@@ -486,7 +485,7 @@ inline void calc_tv(pcm_t& pcm, int e, int adjust, uint16_t *levelcur, int activ
     }
 }
 
-inline int eram_unpack(pcm_t& pcm, int addr, int type = 0)
+inline int eram_unpack(pcm_t& pcm, uint32_t addr, int type = 0)
 {
     addr &= 0x3fff;
     int data = pcm.eram[addr];
@@ -497,7 +496,7 @@ inline int eram_unpack(pcm_t& pcm, int addr, int type = 0)
     return val >> (18 - sh * 2 + type);
 }
 
-inline void eram_pack(pcm_t& pcm, int addr, int val)
+inline void eram_pack(pcm_t& pcm, uint32_t addr, uint32_t val)
 {
     addr &= 0x3fff;
     int sh = 0;
@@ -515,7 +514,7 @@ inline void eram_pack(pcm_t& pcm, int addr, int val)
 
     int data = (val >> (sh * 2)) & 0x3fff;
     data |= sh << 14;
-    pcm.eram[addr] = data;
+    pcm.eram[addr] = (uint16_t)data;
 }
 
 void PCM_GetConfig(PCM_Config& config, uint8_t config_byte)
@@ -587,53 +586,51 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
 {
     while (pcm.cycles < cycles)
     {
-        const int voice_active = pcm.voice_mask & pcm.voice_mask_pending;
+        const uint32_t voice_active = pcm.voice_mask & pcm.voice_mask_pending;
         { // final mixing
             int shifter = pcm.ram2[30][10];
             int xr = ((shifter >> 0) ^ (shifter >> 1) ^ (shifter >> 7) ^ (shifter >> 12)) & 1;
             shifter = (shifter >> 1) | (xr << 15);
-            pcm.ram2[30][10] = shifter;
+            pcm.ram2[30][10] = (uint16_t)shifter;
 
-            pcm.accum_l = addclip20(pcm.accum_l, pcm.ram1[30][0], 0);
-            pcm.accum_r = addclip20(pcm.accum_r, pcm.ram1[30][1], 0);
+            pcm.accum_l = addclip20(pcm.accum_l, (int32_t)pcm.ram1[30][0], 0);
+            pcm.accum_r = addclip20(pcm.accum_r, (int32_t)pcm.ram1[30][1], 0);
 
-            pcm.ram1[30][2] = addclip20(pcm.accum_l,
-                pcm.config.orval | (shifter & pcm.config.noise_mask), 0);
+            pcm.ram1[30][2] = (uint32_t)addclip20(pcm.accum_l,
+                (int32_t)(pcm.config.orval | (shifter & pcm.config.noise_mask)), 0);
 
-            pcm.ram1[30][4] = addclip20(pcm.accum_r,
-                pcm.config.orval | (shifter & pcm.config.noise_mask), 0);
+            pcm.ram1[30][4] = (uint32_t)addclip20(pcm.accum_r,
+                (int32_t)(pcm.config.orval | (shifter & pcm.config.noise_mask)), 0);
 
-            pcm.ram1[30][0] = pcm.accum_l & pcm.config.write_mask;
-            pcm.ram1[30][1] = pcm.accum_r & pcm.config.write_mask;
+            pcm.ram1[30][0] = (uint32_t)(pcm.accum_l & pcm.config.write_mask);
+            pcm.ram1[30][1] = (uint32_t)(pcm.accum_r & pcm.config.write_mask);
 
-
-            int32_t samp_l = (int32_t)((pcm.ram1[30][2] & ~pcm.config.write_mask) << 12);
-            int32_t samp_r = (int32_t)((pcm.ram1[30][4] & ~pcm.config.write_mask) << 12);
+            int32_t samp_l = (int32_t)((pcm.ram1[30][2] & (uint32_t)(~pcm.config.write_mask)) << 12);
+            int32_t samp_r = (int32_t)((pcm.ram1[30][4] & (uint32_t)(~pcm.config.write_mask)) << 12);
 
             MCU_PostSample(*pcm.mcu, {samp_l, samp_r});
 
             xr = ((shifter >> 0) ^ (shifter >> 1) ^ (shifter >> 7) ^ (shifter >> 12)) & 1;
             shifter = (shifter >> 1) | (xr << 15);
 
-            pcm.accum_l = addclip20(pcm.accum_l, pcm.ram1[30][0], 0);
-            pcm.accum_r = addclip20(pcm.accum_r, pcm.ram1[30][1], 0);
+            pcm.accum_l = addclip20(pcm.accum_l, (int32_t)pcm.ram1[30][0], 0);
+            pcm.accum_r = addclip20(pcm.accum_r, (int32_t)pcm.ram1[30][1], 0);
 
-            pcm.ram1[30][3] = addclip20(pcm.accum_l,
-                pcm.config.orval | (shifter & pcm.config.noise_mask), 0);
+            pcm.ram1[30][3] = (uint32_t)addclip20(pcm.accum_l,
+                (int32_t)(pcm.config.orval | (shifter & pcm.config.noise_mask)), 0);
 
-            pcm.ram1[30][5] = addclip20(pcm.accum_r,
-                pcm.config.orval | (shifter & pcm.config.noise_mask), 0);
+            pcm.ram1[30][5] = (uint32_t)addclip20(pcm.accum_r,
+                (int32_t)(pcm.config.orval | (shifter & pcm.config.noise_mask)), 0);
 
-            if (!pcm.disable_oversampling && pcm.config.oversampling) // oversampling
+            if (pcm.enable_oversampling && pcm.config.oversampling) // oversampling
             {
-                pcm.ram2[30][10] = shifter;
+                pcm.ram2[30][10] = (uint16_t)shifter;
 
-                pcm.ram1[30][0] = pcm.accum_l & pcm.config.write_mask;
-                pcm.ram1[30][1] = pcm.accum_r & pcm.config.write_mask;
+                pcm.ram1[30][0] = (uint32_t)(pcm.accum_l & pcm.config.write_mask);
+                pcm.ram1[30][1] = (uint32_t)(pcm.accum_r & pcm.config.write_mask);
 
-
-                samp_l = (int32_t)((pcm.ram1[30][3] & ~pcm.config.write_mask) << 12);
-                samp_r = (int32_t)((pcm.ram1[30][5] & ~pcm.config.write_mask) << 12);
+                samp_l = (int32_t)((pcm.ram1[30][3] & (uint32_t)(~pcm.config.write_mask)) << 12);
+                samp_r = (int32_t)((pcm.ram1[30][5] & (uint32_t)(~pcm.config.write_mask)) << 12);
 
                 MCU_PostSample(*pcm.mcu, {samp_l, samp_r});
             }
@@ -649,7 +646,6 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
         }
 
         // chorus/reverb
-
         { // fixme
             if (pcm.ram2[31][8] & 0x8000)
                 pcm.ram2[31][9] = pcm.ram2[31][8] & 0x7fff;
@@ -661,30 +657,27 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             else
                 pcm.ram2[31][9] = (0x4000 - pcm.ram2[31][8]) & 0x7fff;
         }
-
         {
             int v1 = pcm.ram2[31][1];
 
-            int m1 = multi(pcm.ram1[29][1], v1 >> 8) >> 5; // 14
-            int m2 = multi(pcm.rcsum[1], v1 & 255) >> 5; // 15
+            int m1 = multi((int32_t)pcm.ram1[29][1], (int8_t)(v1 >> 8)) >> 5; // 14
+            int m2 = multi(pcm.rcsum[1], (int8_t)(v1 & 255)) >> 5; // 15
 
-            pcm.ram1[29][1] = addclip20(m1 >> 1, m2 >> 1, (m1 | m2) & 1); // 16
+            pcm.ram1[29][1] = (uint32_t)addclip20(m1 >> 1, m2 >> 1, (m1 | m2) & 1); // 16
         }
-
         {
-            int okey = (pcm.ram2[31][7] & 0x20) != 0;
-            int key = 1;
-            int active = okey && key;
+            const bool okey = (pcm.ram2[31][7] & 0x20) != 0;
+            const bool key = 1;
+            const bool active = okey && key;
             int u = 0;
             calc_tv(pcm, 1, pcm.ram2[30][0], &pcm.ram2[30][9], active, &u);
         }
-
         {
             int v1 = pcm.ram2[30][1];
-            int m1 = multi(pcm.ram1[29][0], v1 >> 8) >> 5; // 17
-            int m2 = multi(pcm.rcsum[0], v1 & 255) >> 5; // 18
+            int m1 = multi((int32_t)pcm.ram1[29][0], (int8_t)(v1 >> 8)) >> 5; // 17
+            int m2 = multi(pcm.rcsum[0], (int8_t)(v1 & 255)) >> 5; // 18
 
-            pcm.ram1[29][0] = addclip20(m1 >> 1, m2 >> 1, (m1 | m2) & 1); // 19
+            pcm.ram1[29][0] = (uint32_t)addclip20(m1 >> 1, m2 >> 1, (m1 | m2) & 1); // 19
         }
 
         int rcadd[6] = {};
@@ -694,7 +687,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             {
                 // 1
                 int v1 = pcm.ram2[30][4];
-                int m1 = multi(pcm.ram1[29][0], (v1 >> 8)) >> 6;
+                int m1 = multi((int32_t)pcm.ram1[29][0], (int8_t)(v1 >> 8)) >> 6;
                 int v2 = 0;
                 int s1 = eram_unpack(pcm, pcm.ram2[28][1] + pcm.tv_counter, 1);
                 int s2 = eram_unpack(pcm, pcm.ram2[28][1] + pcm.tv_counter);
@@ -703,9 +696,9 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                     v2 = s1;
                 }
                 int v3 = addclip20(m1, v2 ^ 0xfffff, 1);
-                pcm.ram1[29][4] = v3;
-                int m2 = multi(v3, v1 & 255) >> 5;
-                pcm.ram1[29][5] = addclip20(m2 >> 1, s2, m2 & 1);
+                pcm.ram1[29][4] = (uint32_t)v3;
+                int m2 = multi(v3, (int8_t)(v1 & 255)) >> 5;
+                pcm.ram1[29][5] = (uint32_t)addclip20(m2 >> 1, s2, m2 & 1);
             }
             {
                 // 2
@@ -717,10 +710,10 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 {
                     v2 = s1;
                 }
-                int v3 = addclip20(pcm.ram1[29][5], v2 ^ 0xfffff, 1);
-                pcm.ram1[29][5] = v3;
-                int m2 = multi(v3, v1 & 255) >> 5;
-                pcm.ram1[28][0] = addclip20(m2 >> 1, s2, m2 & 1);
+                int v3 = addclip20((int32_t)pcm.ram1[29][5], v2 ^ 0xfffff, 1);
+                pcm.ram1[29][5] = (uint32_t)v3;
+                int m2 = multi(v3, (int8_t)(v1 & 255)) >> 5;
+                pcm.ram1[28][0] = (uint32_t)addclip20(m2 >> 1, s2, m2 & 1);
             }
             {
                 // 3
@@ -732,13 +725,12 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 {
                     v2 = s1;
                 }
-                int v3 = addclip20(pcm.ram1[28][0], v2 ^ 0xfffff, 1);
-                pcm.ram1[28][0] = v3;
-                int m2 = multi(v3, v1 & 255) >> 5;
-                pcm.ram1[28][1] = addclip20(m2 >> 1, s2, m2 & 1);
+                int v3 = addclip20((int32_t)pcm.ram1[28][0], v2 ^ 0xfffff, 1);
+                pcm.ram1[28][0] = (uint32_t)v3;
+                int m2 = multi(v3, (int8_t)(v1 & 255)) >> 5;
+                pcm.ram1[28][1] = (uint32_t)addclip20(m2 >> 1, s2, m2 & 1);
 
-
-                pcm.ram1[28][2] = eram_unpack(pcm, pcm.ram2[28][5] + pcm.tv_counter);
+                pcm.ram1[28][2] = (uint32_t)eram_unpack(pcm, pcm.ram2[28][5] + pcm.tv_counter);
             }
             {
                 // 4
@@ -750,33 +742,30 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 {
                     v2 = s1;
                 }
-                int v3 = addclip20(pcm.ram1[28][1], v2 ^ 0xfffff, 1);
-                pcm.ram1[28][1] = v3;
-                int m2 = multi(v3, v1 & 255) >> 5;
-                pcm.ram1[28][3] = addclip20(m2 >> 1, s2, m2 & 1);
+                int v3 = addclip20((int32_t)pcm.ram1[28][1], v2 ^ 0xfffff, 1);
+                pcm.ram1[28][1] = (uint32_t)v3;
+                int m2 = multi(v3, (int8_t)(v1 & 255)) >> 5;
+                pcm.ram1[28][3] = (uint32_t)addclip20(m2 >> 1, s2, m2 & 1);
 
-
-                pcm.ram1[28][4] = eram_unpack(pcm, pcm.ram2[29][1] + pcm.tv_counter);
+                pcm.ram1[28][4] = (uint32_t)eram_unpack(pcm, pcm.ram2[29][1] + pcm.tv_counter);
             }
             {
                 // 5
-
                 int v1 = pcm.ram2[30][7];
-                int m1 = multi(pcm.ram1[29][2], (v1 >> 8)) >> 5;
+                int m1 = multi((int32_t)pcm.ram1[29][2], (int8_t)(v1 >> 8)) >> 5;
                 int s1 = eram_unpack(pcm, pcm.ram2[29][0] + pcm.tv_counter);
-                int m2 = multi(s1, v1 & 255) >> 5;
-                pcm.ram1[29][2] = addclip20(m1 >> 1, m2 >> 1, (m1 | m2) & 1);
+                int m2 = multi(s1, (int8_t)(v1 & 255)) >> 5;
+                pcm.ram1[29][2] = (uint32_t)addclip20(m1 >> 1, m2 >> 1, (m1 | m2) & 1);
 
                 eram_pack(pcm, pcm.ram2[28][0] + pcm.tv_counter, pcm.ram1[29][4]);
             }
             {
                 // 6
-
                 int v1 = pcm.ram2[30][8];
-                int m1 = multi(pcm.ram1[29][3], (v1 >> 8)) >> 5;
+                int m1 = multi((int32_t)pcm.ram1[29][3], (int8_t)(v1 >> 8)) >> 5;
                 int s1 = eram_unpack(pcm, pcm.ram2[29][8] + pcm.tv_counter);
-                int m2 = multi(s1, v1 & 255) >> 5;
-                pcm.ram1[29][3] = addclip20(m1 >> 1, m2 >> 1, (m1 | m2) & 1);
+                int m2 = multi(s1, (int8_t)(v1 & 255)) >> 5;
+                pcm.ram1[29][3] = (uint32_t)addclip20(m1 >> 1, m2 >> 1, (m1 | m2) & 1);
 
                 eram_pack(pcm, pcm.ram2[28][1] + pcm.tv_counter, pcm.ram1[29][5]);
 
@@ -784,70 +773,62 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 7
-
                 int v1 = pcm.ram2[30][9];
-                int v2 = pcm.ram1[28][3];
-                int m1 = multi(pcm.ram1[29][2], (v1 >> 8)) >> 5;
-                int m2 = multi(pcm.ram1[29][3], (v1 >> 8)) >> 5;
-                pcm.ram1[28][3] = addclip20(v2, m1 >> 1, m1 & 1);
-                pcm.ram1[28][5] = addclip20(v2, m2 >> 1, m2 & 1);
+                int v2 = (int)pcm.ram1[28][3];
+                int m1 = multi((int32_t)pcm.ram1[29][2], (int8_t)(v1 >> 8)) >> 5;
+                int m2 = multi((int32_t)pcm.ram1[29][3], (int8_t)(v1 >> 8)) >> 5;
+                pcm.ram1[28][3] = (uint32_t)addclip20(v2, m1 >> 1, m1 & 1);
+                pcm.ram1[28][5] = (uint32_t)addclip20(v2, m2 >> 1, m2 & 1);
 
                 eram_pack(pcm, pcm.ram2[28][3] + pcm.tv_counter, pcm.ram1[28][1]);
             }
             {
                 // 8
-
                 int v1 = pcm.ram2[30][6];
-                int m1 = multi(pcm.ram1[28][2], v1 >> 8) >> 5;
+                int m1 = multi((int32_t)pcm.ram1[28][2], (int8_t)(v1 >> 8)) >> 5;
 
-                int v2 = addclip20(pcm.ram1[28][3], m1 >> 1, m1 & 1);
-                pcm.ram1[28][3] = v2;
-                int m2 = multi(v2, v1 & 255) >> 5;
-                pcm.ram1[28][2] = addclip20(pcm.ram1[28][2], m2 >> 1, m2 & 1);
+                int v2 = addclip20((int32_t)pcm.ram1[28][3], m1 >> 1, m1 & 1);
+                pcm.ram1[28][3] = (uint32_t)v2;
+                int m2 = multi(v2, (int8_t)(v1 & 255)) >> 5;
+                pcm.ram1[28][2] = (uint32_t)addclip20((int32_t)pcm.ram1[28][2], m2 >> 1, m2 & 1);
 
-
-                pcm.ram1[28][1] = eram_unpack(pcm, pcm.ram2[28][9] + pcm.tv_counter);
+                pcm.ram1[28][1] = (uint32_t)eram_unpack(pcm, pcm.ram2[28][9] + pcm.tv_counter);
             }
             {
                 // 9
-
                 int v1 = pcm.ram2[30][6];
-                int m1 = multi(pcm.ram1[28][4], v1 >> 8) >> 5;
+                int m1 = multi((int32_t)pcm.ram1[28][4], (int8_t)(v1 >> 8)) >> 5;
 
-                int v2 = addclip20(pcm.ram1[28][5], m1 >> 1, m1 & 1);
-                pcm.ram1[28][5] = v2;
-                int m2 = multi(v2, v1 & 255) >> 5;
-                pcm.ram1[28][4] = addclip20(pcm.ram1[28][4], m2 >> 1, m2 & 1);
+                int v2 = addclip20((int32_t)pcm.ram1[28][5], m1 >> 1, m1 & 1);
+                pcm.ram1[28][5] = (uint32_t)v2;
+                int m2 = multi(v2, (int8_t)(v1 & 255)) >> 5;
+                pcm.ram1[28][4] = (uint32_t)addclip20((int32_t)pcm.ram1[28][4], m2 >> 1, m2 & 1);
 
-
-                pcm.ram1[29][4] = eram_unpack(pcm, pcm.ram2[29][5] + pcm.tv_counter);
+                pcm.ram1[29][4] = (uint32_t)eram_unpack(pcm, pcm.ram2[29][5] + pcm.tv_counter);
             }
             {
                 // 10
-
                 int v1 = pcm.ram2[30][6];
-                int v2 = pcm.ram1[28][1];
-                int m1 = multi(v2, v1 >> 8) >> 5;
+                int v2 = (int)pcm.ram1[28][1];
+                int m1 = multi(v2, (int8_t)(v1 >> 8)) >> 5;
                 int s1 = eram_unpack(pcm, pcm.ram2[28][8] + pcm.tv_counter);
                 int v3 = addclip20(m1 >> 1, s1, m1 & 1);
-                pcm.ram1[28][1] = v3;
-                int m2 = multi(v3, v1 & 255) >> 5;
-                pcm.ram1[29][5] = addclip20(m2 >> 1, v2, m2 & 1);
+                pcm.ram1[28][1] = (uint32_t)v3;
+                int m2 = multi(v3, (int8_t)(v1 & 255)) >> 5;
+                pcm.ram1[29][5] = (uint32_t)addclip20(m2 >> 1, v2, m2 & 1);
 
                 eram_pack(pcm, pcm.ram2[28][4] + pcm.tv_counter, pcm.ram1[28][3]);
             }
             {
                 // 11
-
                 int v1 = pcm.ram2[30][6];
-                int v2 = pcm.ram1[29][4];
-                int m1 = multi(v2, v1 >> 8) >> 5;
+                int v2 = (int)pcm.ram1[29][4];
+                int m1 = multi(v2, (int8_t)(v1 >> 8)) >> 5;
                 int s1 = eram_unpack(pcm, pcm.ram2[29][4] + pcm.tv_counter);
                 int v3 = addclip20(m1 >> 1, s1, m1 & 1);
-                pcm.ram1[29][4] = v3;
-                int m2 = multi(v3, v1 & 255) >> 5;
-                pcm.ram1[28][0] = addclip20(m2 >> 1, v2, m2 & 1);
-
+                pcm.ram1[29][4] = (uint32_t)v3;
+                int m2 = multi(v3, (int8_t)(v1 & 255)) >> 5;
+                pcm.ram1[28][0] = (uint32_t)addclip20(m2 >> 1, v2, m2 & 1);
 
                 eram_pack(pcm, pcm.ram2[28][5] + pcm.tv_counter, pcm.ram1[28][2]);
 
@@ -855,180 +836,161 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 12
-
-                pcm.ram1[28][5] = eram_unpack(pcm, pcm.ram2[28][6] + pcm.tv_counter);
+                pcm.ram1[28][5] = (uint32_t)eram_unpack(pcm, pcm.ram2[28][6] + pcm.tv_counter);
             }
-
             {
                 // 13
-
                 int s1 = eram_unpack(pcm, pcm.ram2[28][10] + pcm.tv_counter);
-                pcm.ram1[28][5] = addclip20(pcm.ram1[28][5], s1, 0);
+                pcm.ram1[28][5] = (uint32_t)addclip20((int32_t)pcm.ram1[28][5], s1, 0);
 
-                pcm.ram1[28][2] = eram_unpack(pcm, pcm.ram2[29][2] + pcm.tv_counter);
+                pcm.ram1[28][2] = (uint32_t)eram_unpack(pcm, pcm.ram2[29][2] + pcm.tv_counter);
             }
-
             {
                 // 14
-
                 int s1 = eram_unpack(pcm, pcm.ram2[29][6] + pcm.tv_counter);
-                int t1 = addclip20(s1, pcm.ram1[28][2], 0); // 6
+                int t1 = addclip20(s1, (int32_t)pcm.ram1[28][2], 0); // 6
 
-                pcm.ram1[28][5] = addclip20(t1, pcm.ram1[28][5], 0);
+                pcm.ram1[28][5] = (uint32_t)addclip20(t1, (int32_t)pcm.ram1[28][5], 0);
 
-                pcm.ram1[28][2] = eram_unpack(pcm, pcm.ram2[28][7] + pcm.tv_counter);
+                pcm.ram1[28][2] = (uint32_t)eram_unpack(pcm, pcm.ram2[28][7] + pcm.tv_counter);
             }
-
             {
                 // 15
-
                 int s1 = eram_unpack(pcm, pcm.ram2[28][11] + pcm.tv_counter);
-                pcm.ram1[28][2] = addclip20(pcm.ram1[28][2], s1, 0);
+                pcm.ram1[28][2] = (uint32_t)addclip20((int32_t)pcm.ram1[28][2], s1, 0);
 
-                pcm.ram1[28][3] = eram_unpack(pcm, pcm.ram2[29][3] + pcm.tv_counter);
+                pcm.ram1[28][3] = (uint32_t)eram_unpack(pcm, pcm.ram2[29][3] + pcm.tv_counter);
             }
-
             {
                 // 16
-
                 int s1 = eram_unpack(pcm, pcm.ram2[29][7] + pcm.tv_counter);
-                int t1 = addclip20(s1, pcm.ram1[28][2], 0);
-                pcm.ram1[28][2] = addclip20(t1, pcm.ram1[28][3], 0);
-
+                int t1 = addclip20(s1, (int32_t)pcm.ram1[28][2], 0);
+                pcm.ram1[28][2] = (uint32_t)addclip20(t1, (int32_t)pcm.ram1[28][3], 0);
 
                 eram_pack(pcm, pcm.ram2[29][1] + pcm.tv_counter, pcm.ram1[28][4]);
 
                 eram_pack(pcm, pcm.ram2[28][8] + pcm.tv_counter, pcm.ram1[28][1]);
             }
-
             {
                 // 17
                 int v1 = pcm.ram2[30][2];
-                int v2 = pcm.ram1[28][5];
+                int v2 = (int)pcm.ram1[28][5];
 
-                int m1 = multi(v2, v1 >> 8) >> 5;
+                int m1 = multi(v2, (int8_t)(v1 >> 8)) >> 5;
 
                 rcadd[0] = m1;
 
-                rcadd2[0] = multi(v2, v1 & 255) >> 5;
+                rcadd2[0] = multi(v2, (int8_t)(v1 & 255)) >> 5;
 
                 int t1 = eram_unpack(pcm, pcm.ram2[29][10] + pcm.tv_counter + 1); //? 3a6e
                 eram_pack(pcm, pcm.ram2[28][9] + pcm.tv_counter, pcm.ram1[29][5]);
-                pcm.ram1[29][5] = t1;
+                pcm.ram1[29][5] = (uint32_t)t1;
             }
-
             {
                 // 18
                 int v1 = pcm.ram2[30][3];
-                int v2 = pcm.ram1[28][2];
+                int v2 = (int)pcm.ram1[28][2];
 
-                int m1 = multi(v2, v1 >> 8) >> 5;
+                int m1 = multi(v2, (int8_t)(v1 >> 8)) >> 5;
 
                 rcadd[1] = m1;
 
-                rcadd2[1] = multi(v2, v1 & 255) >> 5;
+                rcadd2[1] = multi(v2, (int8_t)(v1 & 255)) >> 5;
 
-                pcm.ram1[28][1] = eram_unpack(pcm, pcm.ram2[29][11] + pcm.tv_counter + 1); //? 3a1e
+                pcm.ram1[28][1] = (uint32_t)eram_unpack(pcm, pcm.ram2[29][11] + pcm.tv_counter + 1); //? 3a1e
             }
             {
                 // 19
-
                 int v1 = pcm.ram2[31][9];
 
                 int s1 = eram_unpack(pcm, pcm.ram2[29][10] + pcm.tv_counter); //? 3a6d
 
                 eram_pack(pcm, pcm.ram2[29][4] + pcm.tv_counter, pcm.ram1[29][4]);
 
-                int m1 = multi(s1, v1 >> 8) >> 5;
-                int m2 = multi(pcm.ram1[29][5], v1 >> 8) >> 5;
+                int m1 = multi(s1, (int8_t)(v1 >> 8)) >> 5;
+                int m2 = multi((int32_t)pcm.ram1[29][5], (int8_t)(v1 >> 8)) >> 5;
 
                 int t2 = addclip20(s1, (m1 >> 1) ^ 0xfffff, 1);
 
-                pcm.ram1[29][5] = addclip20(t2, m2 >> 1, m2 & 1);
+                pcm.ram1[29][5] = (uint32_t)addclip20(t2, m2 >> 1, m2 & 1);
             }
             {
                 // 20
-
                 int v1 = pcm.ram2[31][10];
 
                 int s1 = eram_unpack(pcm, pcm.ram2[29][11] + pcm.tv_counter); //? 3a1d
 
                 eram_pack(pcm, pcm.ram2[29][5] + pcm.tv_counter, pcm.ram1[28][0]);
 
-                int m1 = multi(s1, v1 >> 8) >> 5;
-                int m2 = multi(pcm.ram1[28][1], v1 >> 8) >> 5;
+                int m1 = multi(s1, (int8_t)(v1 >> 8)) >> 5;
+                int m2 = multi((int32_t)pcm.ram1[28][1], (int8_t)(v1 >> 8)) >> 5;
 
                 int t2 = addclip20(s1, (m1 >> 1) ^ 0xfffff, 1);
 
-                pcm.ram1[28][1] = addclip20(t2, m2 >> 1, m2 & 1);
+                pcm.ram1[28][1] = (uint32_t)addclip20(t2, m2 >> 1, m2 & 1);
 
                 eram_pack(pcm, pcm.ram2[29][9] + pcm.tv_counter, pcm.ram1[29][1]);
             }
             {
                 // 21
-
                 int v1 = pcm.ram2[31][2];
-                int v2 = pcm.ram1[29][5];
+                int v2 = (int)pcm.ram1[29][5];
 
-                int m1 = multi(v2, v1 >> 8) >> 5;
-                int m2 = multi(v2, v1 & 255) >> 5;
+                int m1 = multi(v2, (int8_t)(v1 >> 8)) >> 5;
+                int m2 = multi(v2, (int8_t)(v1 & 255)) >> 5;
 
                 rcadd[2] = m1;
                 rcadd2[2] = m2;
             }
             {
                 // 22
-
                 int v1 = pcm.ram2[31][3];
-                int v2 = pcm.ram1[29][5];
+                int v2 = (int)pcm.ram1[29][5];
 
-                int m1 = multi(v2, v1 >> 8) >> 5;
-                int m2 = multi(v2, v1 & 255) >> 5;
+                int m1 = multi(v2, (int8_t)(v1 >> 8)) >> 5;
+                int m2 = multi(v2, (int8_t)(v1 & 255)) >> 5;
 
                 rcadd[3] = m1;
                 rcadd2[3] = m2;
             }
             {
                 // 23
-
                 int v1 = pcm.ram2[31][4];
-                int v2 = pcm.ram1[28][1];
+                int v2 = (int)pcm.ram1[28][1];
 
-                int m1 = multi(v2, v1 >> 8) >> 5;
-                int m2 = multi(v2, v1 & 255) >> 5;
+                int m1 = multi(v2, (int8_t)(v1 >> 8)) >> 5;
+                int m2 = multi(v2, (int8_t)(v1 & 255)) >> 5;
 
                 rcadd[4] = m1;
                 rcadd2[4] = m2;
             }
             {
                 // 31
-
                 int v1 = pcm.ram2[31][5];
-                int v2 = pcm.ram1[28][1];
+                int v2 = (int)pcm.ram1[28][1];
 
-                int m1 = multi(v2, v1 >> 8) >> 5;
-                int m2 = multi(v2, v1 & 255) >> 5;
+                int m1 = multi(v2, (int8_t)(v1 >> 8)) >> 5;
+                int m2 = multi(v2, (int8_t)(v1 & 255)) >> 5;
 
                 rcadd[5] = m1;
                 rcadd2[5] = m2;
 
                 {
                     // address generator
+                    const bool key = 1;
+                    const bool okey = (pcm.ram2[31][7] & 0x20) != 0;
+                    const bool active = key && okey;
+                    const bool kon = key && !okey;
 
-                    int key = 1;
-                    int okey = (pcm.ram2[31][7] & 0x20) != 0;
-                    int active = key && okey;
-                    int kon = key && !okey;
-
-                    int b15 = (pcm.ram2[31][8] & 0x8000) != 0; // 0
-                    int b6 = (pcm.ram2[31][7] & 0x40) != 0; // 1
-                    int b7 = (pcm.ram2[31][7] & 0x80) != 0; // 1
+                    bool b15 = (pcm.ram2[31][8] & 0x8000) != 0; // 0
+                    const bool b6 = (pcm.ram2[31][7] & 0x40) != 0; // 1
+                    const bool b7 = (pcm.ram2[31][7] & 0x80) != 0; // 1
                     int old_nibble = (pcm.ram2[31][7] >> 12) & 15; // 1
                     (void)old_nibble; // unused
 
-                    int address = pcm.ram1[31][4]; // 0
-                    int address_end = pcm.ram1[31][0]; // 1 or 2
-                    int address_loop = pcm.ram1[31][2]; // 2 or 1
+                    int address = (int)pcm.ram1[31][4]; // 0
+                    int address_end = (int)pcm.ram1[31][0]; // 1 or 2
+                    int address_loop = (int)pcm.ram1[31][2]; // 2 or 1
 
                     int sub_phase = (pcm.ram2[31][8] & 0x3fff); // 1
                     int interp_ratio = (sub_phase >> 7) & 127;
@@ -1041,14 +1003,13 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                         pcm.ram2[31][8] |= sub_phase & 0x3fff;
                     }
 
-
                     // address 0
                     int address_cnt = address;
 
                     int cmp1 = b15 ? address_loop : address_end;
                     int cmp2 = address_cnt;
-                    int address_cmp = (cmp1 & 0xfffff) == (cmp2 & 0xfffff); // 9
-                    int next_b15 = b15;
+                    bool address_cmp = (cmp1 & 0xfffff) == (cmp2 & 0xfffff); // 9
+                    bool next_b15 = b15;
 
                     int next_address = address_cnt; // 11
 
@@ -1056,8 +1017,8 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                     cmp2 = address_cnt;
                     int address_cnt2 = (kon || (!b6 && address_cmp)) ? cmp1 : cmp2;
 
-                    int address_add = (!address_cmp && b6 && !b15) || (!address_cmp && !b6);
-                    int address_sub = !address_cmp && b6 && b15;
+                    const bool address_add = (!address_cmp && b6 && !b15) || (!address_cmp && !b6);
+                    const bool address_sub = !address_cmp && b6 && b15;
                     if (b7)
                         address_cnt2 -= address_add - address_sub;
                     else
@@ -1076,21 +1037,21 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                     }
 
                     if (active && pcm.nfs)
-                        pcm.ram1[31][4] = next_address;
+                        pcm.ram1[31][4] = (uint32_t)next_address;
 
                     if (pcm.nfs)
                     {
                         pcm.ram2[31][8] &= ~0x8000;
-                        pcm.ram2[31][8] |= next_b15 << 15;
+                        pcm.ram2[31][8] |= (uint16_t)(next_b15 << 15);
                     }
 
                     int t1 = address_loop; // 18
-                    int t2 = pcm.ram1[31][4] - t1; // 19
+                    int t2 = (int)pcm.ram1[31][4] - t1; // 19
                     int t3 = address_end - t2; // 20
-                    int t4 = pcm.ram1[31][4]; // 23
+                    int t4 = (int)pcm.ram1[31][4]; // 23
 
-                    pcm.ram2[29][10] = t3;
-                    pcm.ram2[29][11] = t4;
+                    pcm.ram2[29][10] = (uint16_t)t3;
+                    pcm.ram2[29][11] = (uint16_t)t4;
                 }
             }
         }
@@ -1104,28 +1065,27 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
         {
             uint32_t *ram1 = pcm.ram1[slot];
             uint16_t *ram2 = pcm.ram2[slot];
-            int okey = (ram2[7] & 0x20) != 0;
-            int key = (voice_active >> slot) & 1;
+            const bool okey = (ram2[7] & 0x20) != 0;
+            const bool key = (voice_active >> slot) & 1;
 
-            int active = okey && key;
-            int kon = key && !okey;
+            const bool active = okey && key;
+            const bool kon = key && !okey;
 
             // address generator
-
-            int b15 = (ram2[8] & 0x8000) != 0; // 0
-            int b6 = (ram2[7] & 0x40) != 0; // 1
-            int b7 = (ram2[7] & 0x80) != 0; // 1
+            bool b15 = (ram2[8] & 0x8000) != 0; // 0
+            const bool b6 = (ram2[7] & 0x40) != 0; // 1
+            const bool b7 = (ram2[7] & 0x80) != 0; // 1
             int hiaddr = (ram2[7] >> 8) & 15; // 1
             int old_nibble = (ram2[7] >> 12) & 15; // 1
 
-            int address = ram1[4]; // 0
-            int address_end = ram1[0]; // 1 or 2
-            int address_loop = ram1[2]; // 2 or 1
+            int address = (int)ram1[4]; // 0
+            int address_end = (int)ram1[0]; // 1 or 2
+            int address_loop = (int)ram1[2]; // 2 or 1
 
             int cmp1 = b15 ? address_loop : address_end;
             int cmp2 = address;
-            int nibble_cmp1 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 2
-            int irq_flag = 0;
+            const bool nibble_cmp1 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 2
+            bool irq_flag = 0;
 
             // fixme:
             if (kon)
@@ -1135,21 +1095,21 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             irq_flag ^= b7;
 
             int nibble_address = (!b6 && nibble_cmp1) ? address_loop : address; // 3
-            int address_b4 = (nibble_address & 0x10) != 0;
+            const bool address_b4 = (nibble_address & 0x10) != 0;
             int wave_address = nibble_address >> 5;
-            int xor2 = (address_b4 ^ b7);
-            int check1 = xor2 && active;
-            int xor1 = (b15 ^ !nibble_cmp1);
-            int nibble_add = b6 ? check1 && xor1 : (!nibble_cmp1 && check1);
-            int nibble_subtract = b6 && !xor1 && active && !xor2;
+            const bool xor2 = (address_b4 ^ b7);
+            const bool check1 = xor2 && active;
+            const bool xor1 = (b15 ^ !nibble_cmp1);
+            const bool nibble_add = b6 ? check1 && xor1 : (!nibble_cmp1 && check1);
+            const bool nibble_subtract = b6 && !xor1 && active && !xor2;
             if (b7)
                 wave_address -= nibble_add - nibble_subtract;
             else
                 wave_address += nibble_add - nibble_subtract;
             wave_address &= 0xfffff;
 
-            int newnibble = PCM_ReadROM(pcm, (hiaddr << 20) | wave_address);
-            int newnibble_sel = address_b4 ^ ((b6 || !nibble_cmp1) && okey);
+            int newnibble = PCM_ReadROM(pcm, (uint32_t)((hiaddr << 20) | wave_address));
+            const bool newnibble_sel = address_b4 ^ ((b6 || !nibble_cmp1) && okey);
             if (newnibble_sel)
                 newnibble = (newnibble >> 4) & 15;
             else
@@ -1165,28 +1125,27 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 ram2[8] |= sub_phase & 0x3fff;
             }
 
-
             // address 0
             int address_cnt = address;
-            int samp0 = (int8_t)PCM_ReadROM(pcm, (hiaddr << 20) | address_cnt); // 18
+            int samp0 = (int8_t)PCM_ReadROM(pcm, (uint32_t)((hiaddr << 20) | address_cnt)); // 18
 
             cmp1 = address;
             cmp2 = address_cnt;
-            int nibble_cmp2 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 8
+            const bool nibble_cmp2 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 8
             cmp1 = b15 ? address_loop : address_end;
             cmp2 = address_cnt;
-            int address_cmp = (cmp1 & 0xfffff) == (cmp2 & 0xfffff); // 9
+            bool address_cmp = (cmp1 & 0xfffff) == (cmp2 & 0xfffff); // 9
 
             int next_address = address_cnt; // 11
-            int usenew = !nibble_cmp2;
-            int next_b15 = b15;
+            bool usenew = !nibble_cmp2;
+            bool next_b15 = b15;
 
             cmp1 = (!b6 && address_cmp) ? address_loop : address_cnt;
             cmp2 = address_cnt;
             int address_cnt2 = (kon || (!b6 && address_cmp)) ? cmp1 : cmp2;
 
-            int address_add = (!address_cmp && b6 && !b15) || (!address_cmp && !b6);
-            int address_sub = !address_cmp && b6 && b15;
+            bool address_add = (!address_cmp && b6 && !b15) || (!address_cmp && !b6);
+            bool address_sub = !address_cmp && b6 && b15;
             if (b7)
                 address_cnt2 -= address_add - address_sub;
             else
@@ -1194,11 +1153,11 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             address_cnt = address_cnt2 & 0xfffff; // 11
             b15 = b6 && (b15 ^ address_cmp); // 11
 
-            int samp1 = (int8_t)PCM_ReadROM(pcm, (hiaddr << 20) | address_cnt); // 20
+            int samp1 = (int8_t)PCM_ReadROM(pcm, (uint32_t)((hiaddr << 20) | address_cnt)); // 20
 
             cmp1 = address;
             cmp2 = address_cnt;
-            int nibble_cmp3 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 12
+            const bool nibble_cmp3 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 12
             cmp1 = b15 ? address_loop : address_end;
             cmp2 = address_cnt;
             address_cmp = (cmp1 & 0xfffff) == (cmp2 & 0xfffff); // 13
@@ -1223,11 +1182,11 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             address_cnt = address_cnt2 & 0xfffff; // 15
             b15 = b6 && (b15 ^ address_cmp); // 15
 
-            int samp2 = (int8_t)PCM_ReadROM(pcm, (hiaddr << 20) | address_cnt); // 1
+            int samp2 = (int8_t)PCM_ReadROM(pcm, (uint32_t)((hiaddr << 20) | address_cnt)); // 1
 
             cmp1 = address;
             cmp2 = address_cnt;
-            int nibble_cmp4 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 16
+            const bool nibble_cmp4 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 16
             cmp1 = b15 ? address_loop : address_end;
             cmp2 = address_cnt;
             address_cmp = (cmp1 & 0xfffff) == (cmp2 & 0xfffff); // 17
@@ -1252,11 +1211,11 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             address_cnt = address_cnt2 & 0xfffff; // 19
             b15 = b6 && (b15 ^ address_cmp); // 19
 
-            int samp3 = (int8_t)PCM_ReadROM(pcm, (hiaddr << 20) | address_cnt); // 5
+            int samp3 = (int8_t)PCM_ReadROM(pcm, (uint32_t)((hiaddr << 20) | address_cnt)); // 5
 
             cmp1 = address;
             cmp2 = address_cnt;
-            int nibble_cmp5 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 20
+            const bool nibble_cmp5 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 20
             cmp1 = b15 ? address_loop : address_end;
             cmp2 = address_cnt;
             address_cmp = (cmp1 & 0xfffff) == (cmp2 & 0xfffff); // 21
@@ -1283,7 +1242,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
 
             cmp1 = address;
             cmp2 = address_cnt;
-            int nibble_cmp6 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 24
+            const bool nibble_cmp6 = (cmp1 & 0xffff0) == (cmp2 & 0xffff0); // 24
 
             if (sub_phase_of >= 4)
             {
@@ -1293,18 +1252,17 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
 
             if (active && pcm.nfs)
-                ram1[4] = next_address;
+                ram1[4] = (uint32_t)next_address;
 
             if (pcm.nfs)
             {
                 ram2[8] &= ~0x8000;
-                ram2[8] |= next_b15 << 15;
+                ram2[8] |= (uint16_t)(next_b15 << 15);
             }
 
             // dpcm
-
             // 18
-            int reference = ram1[5];
+            int reference = (int)ram1[5];
 
             // 19
             int preshift = samp0 << 10;
@@ -1344,10 +1302,9 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 reference = addclip20(reference, shifted >> 1, shifted & 1);
 
             // interpolation
+            int test = (int)ram1[5];
 
-            int test = ram1[5];
-
-            int step0 = multi(interp_lut[0][interp_ratio] << 6, samp0) >> 8;
+            int step0 = multi(interp_lut[0][interp_ratio] << 6, (int8_t)samp0) >> 8;
             select_nibble = nibble_cmp2 ? old_nibble : newnibble;
             shift = (10 - select_nibble) & 15;
             step0 =  (step0 << 1) >> shift;
@@ -1355,20 +1312,20 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             test = addclip20(test, step0 >> 1, step0 & 1);
 
 
-            int step1 = multi(interp_lut[1][interp_ratio] << 6, samp1) >> 8;
+            int step1 = multi(interp_lut[1][interp_ratio] << 6, (int8_t)samp1) >> 8;
             select_nibble = nibble_cmp3 ? old_nibble : newnibble;
             shift = (10 - select_nibble) & 15;
             step1 = (step1 << 1) >> shift;
 
             test = addclip20(test, step1 >> 1, step1 & 1);
 
-            int step2 = multi(interp_lut[2][interp_ratio] << 6, samp2) >> 8;
+            int step2 = multi(interp_lut[2][interp_ratio] << 6, (int8_t)samp2) >> 8;
             select_nibble = nibble_cmp4 ? old_nibble : newnibble;
             shift = (10 - select_nibble) & 15;
             step2 = (step2 << 1) >> shift;
 
-            int reg1 = ram1[1];
-            int reg3 = ram1[3];
+            int reg1 = (int)ram1[1];
+            int reg3 = (int)ram1[3];
             int reg2_6 = (ram2[6] >> 8) & 127;
 
             test = addclip20(test, step2 >> 1, step2 & 1);
@@ -1378,24 +1335,24 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
 
             if (pcm.mcu->is_mk1)
             {
-                int mult1 = multi(reg1, filter >> 8); // 8
-                int mult2 = multi(reg1, (filter >> 1) & 127); // 9
-                int mult3 = multi(reg1, reg2_6); // 10
+                int mult1 = multi(reg1, (int8_t)(filter >> 8)); // 8
+                int mult2 = multi(reg1, (int8_t)((filter >> 1) & 127)); // 9
+                int mult3 = multi(reg1, (int8_t)reg2_6); // 10
 
                 int v2 = addclip20(reg3, mult1 >> 6, (mult1 >> 5) & 1); // 9
                 int v1 = addclip20(v2, mult2 >> 13, (mult2 >> 12) & 1); // 10
                 int subvar = addclip20(v1, (mult3 >> 6), (mult3 >> 5) & 1); // 11
 
-                ram1[3] = v1;
+                ram1[3] = (uint32_t)v1;
 
                 v3 = addclip20(test, subvar ^ 0xfffff, 1); // 12
 
-                int mult4 = multi(v3, filter >> 8);
-                int mult5 = multi(v3, (filter >> 1) & 127);
+                int mult4 = multi(v3, (int8_t)(filter >> 8));
+                int mult5 = multi(v3, (int8_t)((filter >> 1) & 127));
                 int v4 = addclip20(reg1, mult4 >> 6, (mult4 >> 5) & 1); // 14
                 int v5 = addclip20(v4, mult5 >> 13, (mult5 >> 12) & 1); // 15
 
-                ram1[1] = v5;
+                ram1[1] = (uint32_t)v5;
             }
             else
             {
@@ -1408,7 +1365,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 int v1 = v2 + (mult2 >> 13) + ((mult2 >> 12) & 1); // 10
                 int subvar = v1 + (mult3 >> 6) + ((mult3 >> 5) & 1); // 11
 
-                ram1[3] = v1;
+                ram1[3] = (uint32_t)v1;
 
                 int tests = test;
                 tests <<= 12;
@@ -1421,19 +1378,19 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 int v4 = reg1 + (mult4 >> 6) + ((mult4 >> 5) & 1); // 14
                 int v5 = v4 + (mult5 >> 13) + ((mult5 >> 12) & 1); // 15
 
-                ram1[1] = v5;
+                ram1[1] = (uint32_t)v5;
             }
 
 
-            ram1[5] = reference;
+            ram1[5] = (uint32_t)reference;
 
             if (active && (ram2[6] & 1) != 0 && (ram2[8] & 0x4000) == 0 && !pcm.irq_assert && irq_flag)
             {
                 //fprintf(stderr, "irq voice %i\n", slot);
                 if (pcm.nfs)
                     ram2[8] |= 0x4000;
-                pcm.irq_assert = 1;
-                pcm.irq_channel = slot;
+                pcm.irq_assert = true;
+                pcm.irq_channel = (uint8_t)slot;
                 if (pcm.mcu->is_jv880)
                     MCU_GA_SetGAInt(*pcm.mcu, 5, 1);
                 else
@@ -1450,56 +1407,55 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             // if (volmul1 && volmul2)
             //     volmul1 += 0;
 
-            int sample = (ram2[6] & 2) == 0 ? ram1[3] : v3;
+            int sample = (ram2[6] & 2) == 0 ? (int)ram1[3] : v3;
             //sample = test;
 
-            int multiv1 = multi(sample, volmul1 >> 8);
-            int multiv2 = multi(sample, (volmul1 >> 1) & 127);
+            int multiv1 = multi(sample, (int8_t)(volmul1 >> 8));
+            int multiv2 = multi(sample, (int8_t)((volmul1 >> 1) & 127));
 
             int sample2 = addclip20(multiv1 >> 6, multiv2 >> 13, ((multiv2 >> 12) | (multiv1 >> 5)) & 1);
 
-            int multiv3 = multi(sample2, volmul2 >> 8);
-            int multiv4 = multi(sample2, (volmul2 >> 1) & 127);
+            int multiv3 = multi(sample2, (int8_t)(volmul2 >> 8));
+            int multiv4 = multi(sample2, (int8_t)((volmul2 >> 1) & 127));
 
             int sample3 = addclip20(multiv3 >> 6, multiv4 >> 13, ((multiv4 >> 12) | (multiv3 >> 5)) & 1);
 
             int pan = active ? ram2[1] : 0;
             int rc = active ? ram2[2] : 0;
 
-            int sampl = multi(sample3, (pan >> 8) & 255);
-            int sampr = multi(sample3, (pan >> 0) & 255);
+            int sampl = multi(sample3, (int8_t)((pan >> 8) & 255));
+            int sampr = multi(sample3, (int8_t)((pan >> 0) & 255));
 
-            int rc0 = multi(sample3, (rc >> 8) & 255) >> 5; // reverb
-            int rc1 = multi(sample3, (rc >> 0) & 255) >> 5; // chorus
+            int rc0 = multi(sample3, (int8_t)((rc >> 8) & 255)) >> 5; // reverb
+            int rc1 = multi(sample3, (int8_t)((rc >> 0) & 255)) >> 5; // chorus
 
             // mix reverb/chorus?
             int slot2 = (slot == pcm.config.reg_slots - 1) ? 31 : slot + 1;
             switch (slot2)
             {
                 // 17, 18 - reverb
-
                 case 17:
-                    pcm.ram1[31][1] = addclip20(pcm.ram1[31][1], rcadd[0] >> 1, rcadd[0] & 1);
+                    pcm.ram1[31][1] = (uint32_t)addclip20((int32_t)pcm.ram1[31][1], rcadd[0] >> 1, rcadd[0] & 1);
                     break;
                 case 18:
-                    pcm.ram1[31][3] = addclip20(pcm.ram1[31][3], rcadd[1] >> 1, rcadd[1] & 1);
+                    pcm.ram1[31][3] = (uint32_t)addclip20((int32_t)pcm.ram1[31][3], rcadd[1] >> 1, rcadd[1] & 1);
                     break;
                 case 21:
-                    pcm.ram1[31][1] = addclip20(pcm.ram1[31][1], rcadd[2] >> 1, rcadd[2] & 1);
+                    pcm.ram1[31][1] = (uint32_t)addclip20((int32_t)pcm.ram1[31][1], rcadd[2] >> 1, rcadd[2] & 1);
                     break;
                 case 22:
-                    pcm.ram1[31][3] = addclip20(pcm.ram1[31][3], rcadd[3] >> 1, rcadd[3] & 1);
+                    pcm.ram1[31][3] = (uint32_t)addclip20((int32_t)pcm.ram1[31][3], rcadd[3] >> 1, rcadd[3] & 1);
                     break;
                 case 23:
-                    pcm.ram1[31][1] = addclip20(pcm.ram1[31][1], rcadd[4] >> 1, rcadd[4] & 1);
+                    pcm.ram1[31][1] = (uint32_t)addclip20((int32_t)pcm.ram1[31][1], rcadd[4] >> 1, rcadd[4] & 1);
                     break;
                 case 31:
-                    pcm.ram1[31][3] = addclip20(pcm.ram1[31][3], rcadd[5] >> 1, rcadd[5] & 1);
+                    pcm.ram1[31][3] = (uint32_t)addclip20((int32_t)pcm.ram1[31][3], rcadd[5] >> 1, rcadd[5] & 1);
                     break;
             }
 
-            int suml = addclip20(pcm.ram1[31][1], sampl >> 6, (sampl >> 5) & 1);
-            int sumr = addclip20(pcm.ram1[31][3], sampr >> 6, (sampr >> 5) & 1);
+            int32_t suml = addclip20((int32_t)pcm.ram1[31][1], sampl >> 6, (sampl >> 5) & 1);
+            int32_t sumr = addclip20((int32_t)pcm.ram1[31][3], sampr >> 6, (sampr >> 5) & 1);
 
             switch (slot2)
             {
@@ -1528,8 +1484,8 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
 
             if (slot != pcm.config.reg_slots - 1)
             {
-                pcm.ram1[31][1] = suml;
-                pcm.ram1[31][3] = sumr;
+                pcm.ram1[31][1] = (uint32_t)suml;
+                pcm.ram1[31][3] = (uint32_t)sumr;
             }
             else
             {
@@ -1540,10 +1496,10 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             if (key && pcm.nfs)
             {
                 ram2[7] &= ~0xf020;
-                ram2[7] |= ((usenew || kon) ? newnibble : old_nibble) << 12;
+                ram2[7] |= (uint16_t)(((usenew || kon) ? newnibble : old_nibble) << 12);
 
                 // update key
-                ram2[7] |= key << 5;
+                ram2[7] |= (uint16_t)(key << 5);
             }
 
             if (!active)
@@ -1566,9 +1522,9 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             pcm.ram2[31][7] |= 0x20;
         }
 
-        pcm.nfs = 1;
+        pcm.nfs = true;
 
-        int new_cycles = (pcm.config.reg_slots + 1) * 25;
+        uint64_t new_cycles = (uint64_t)(pcm.config.reg_slots + 1) * 25;
 
         pcm.cycles += pcm.mcu->is_jv880 ? (new_cycles * 25) / 29 : new_cycles;
     }
@@ -1577,12 +1533,12 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
 uint32_t PCM_GetOutputFrequency(const pcm_t& pcm)
 {
     uint32_t freq = (pcm.mcu->is_mk1 || pcm.mcu->is_jv880) ? 64000 : 66207;
-    if (pcm.disable_oversampling)
+    if (pcm.enable_oversampling)
     {
-        return freq / 2;
+        return freq;
     }
     else
     {
-        return freq;
+        return freq / 2;
     }
 }

--- a/src/nuked-sc55/backend/pcm.h
+++ b/src/nuked-sc55/backend/pcm.h
@@ -41,48 +41,44 @@ struct mcu_t;
 struct PCM_Config
 {
     // config_reg_3c
-    int noise_mask = 0;
-    int orval      = 0;
-    int write_mask = 0;
-    int dac_mask   = 0; // unused
-
-    bool oversampling = false;
+    uint32_t orval        = 0;
+    int      dac_mask     = 0; // unused
+    uint8_t  noise_mask   = 0;
+    uint8_t  write_mask   = 0;
+    bool     oversampling = false;
 
     // config_reg_3d
     // important that this starts at 1, see derivation in PCM_Write
-    int reg_slots = 1;
+    uint8_t reg_slots = 1;
 };
 
-struct pcm_t {
+struct pcm_t
+{
     uint32_t ram1[32][8]{};
     uint16_t ram2[32][16]{};
-    uint32_t select_channel = 0;
-    uint32_t voice_mask = 0;
-    uint32_t voice_mask_pending = 0;
-    uint32_t voice_mask_updating = 0;
-    uint32_t write_latch = 0;
-    uint32_t wave_read_address = 0;
-    uint8_t wave_byte_latch = 0;
-    uint32_t read_latch = 0;
-    uint8_t config_reg_3c = 0; // SC55:c3 JV880:c0
-    uint8_t config_reg_3d = 0;
-    uint32_t irq_channel = 0;
-    uint32_t irq_assert = 0;
+    mcu_t*   mcu                 = nullptr;
+    uint64_t cycles              = 0;
+    uint32_t voice_mask          = 0; // same size as voice_mask_pending
+    uint32_t voice_mask_pending  = 0; // 28 bits wide?
+    uint32_t write_latch         = 0; // 20 bits wide?
+    uint32_t read_latch          = 0; // 20 bits wide?
+    uint32_t wave_read_address   = 0;
+    uint16_t tv_counter          = 0; // 14 bits wide?
+    uint8_t  wave_byte_latch     = 0;
+    uint8_t  select_channel      = 0; // 5 bits wide?
+    uint8_t  config_reg_3c       = 0; // SC55:c3 JV880:c0
+    uint8_t  config_reg_3d       = 0;
+    uint8_t  irq_channel         = 0; // range 1..32
+    bool     irq_assert          = 0;
+    bool     voice_mask_updating = false;
+    bool     nfs                 = false;
+    int32_t  accum_l             = 0;
+    int32_t  accum_r             = 0;
+    int32_t  rcsum[2]{};
+
     PCM_Config config{};
 
-    uint32_t nfs = 0;
-
-    uint32_t tv_counter = 0;
-
-    uint64_t cycles = 0;
-
     uint16_t eram[0x4000]{};
-
-    int accum_l = 0;
-    int accum_r = 0;
-    int rcsum[2]{};
-
-    mcu_t* mcu = nullptr;
 
     uint8_t waverom1[0x200000]{};
     uint8_t waverom2[0x200000]{};
@@ -90,7 +86,7 @@ struct pcm_t {
     uint8_t waverom_card[0x200000]{};
     uint8_t waverom_exp[0x800000]{};
 
-    bool disable_oversampling = false;
+    bool enable_oversampling = true;
 };
 
 void PCM_Write(pcm_t& pcm, uint32_t address, uint8_t data);

--- a/src/nuked-sc55/backend/rom_io.cpp
+++ b/src/nuked-sc55/backend/rom_io.cpp
@@ -234,11 +234,11 @@ constexpr uint8_t HexValue(char x)
 {
     if (x >= '0' && x <= '9')
     {
-        return x - '0';
+        return (uint8_t)(x - '0');
     }
     else if (x >= 'a' && x <= 'f')
     {
-        return 10 + (x - 'a');
+        return 10 + (uint8_t)(x - 'a');
     }
     else
     {
@@ -255,7 +255,7 @@ constexpr SHA256Digest ToDigest(const char (&s)[N])
     SHA256Digest hash;
     for (size_t i = 0; i < N / 2; ++i)
     {
-        hash[i] = (HexValue(s[2 * i + 0]) << 4) | HexValue(s[2 * i + 1]);
+        hash[i] = (uint8_t)((HexValue(s[2 * i + 0]) << 4) | HexValue(s[2 * i + 1]));
     }
 
     return hash;
@@ -270,6 +270,23 @@ struct KnownHash
 
 // clang-format off
 static constexpr KnownHash ROM_HASHES[] = {
+    ///////////////////////////////////////////////////////////////////////////
+    // SC-55mk2 (v1.00)
+    ///////////////////////////////////////////////////////////////////////////
+    
+    // TODO: missing hashes for this ROM set
+
+    // R15199848 (H8/532 mcu)
+    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::MK2, RomLocation::ROM1},
+    // R15199859 (H8/532 extra code)
+    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::MK2, RomLocation::ROM2},
+    // R15209463 (M37450M2 mcu)
+    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::MK2, RomLocation::SMROM},
+    // R15209359 (WAVE 16M)
+    {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), Romset::MK2, RomLocation::WAVEROM1},
+    // R15279813 (WAVE 8M)
+    {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), Romset::MK2, RomLocation::WAVEROM2},
+
     ///////////////////////////////////////////////////////////////////////////
     // SC-55mk2/SC-155mk2 (v1.01)
     ///////////////////////////////////////////////////////////////////////////
@@ -303,7 +320,7 @@ static constexpr KnownHash ROM_HASHES[] = {
     // R15199858 (H8/532 mcu)
     {ToDigest("8a1eb33c7599b746c0c50283e4349a1bb1773b5c0ec0e9661219bf6c067d2042"), Romset::ST, RomLocation::ROM1},
     // R00561413 (H8/532 extra code)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::ST, RomLocation::ROM2},
+    {ToDigest("03517ac0a3b1ad8b69a1a4ee045e0c21da0170027bd1ba1bd3cf72cd017bbe6a"), Romset::ST, RomLocation::ROM2},
     // R15199880 (M37450M2 mcu)
     {ToDigest("b0b5f865a403f7308b4be8d0ed3ba2ed1c22db881b8a8326769dea222f6431d8"), Romset::ST, RomLocation::SMROM},
     // R15209359 (WAVE 16M)
@@ -317,7 +334,7 @@ static constexpr KnownHash ROM_HASHES[] = {
 
     // R15199748 (H8/532 mcu)
     {ToDigest("b4ecf44bc0520322b0d114d397951d3bf92ca6fa51d0d27b2407df58a6be2efe"), Romset::MK1, RomLocation::ROM1},
-    // R1544925800 (H8/532 extra code)
+    // R15449258 (H8/532 extra code)
     {ToDigest("014e2e21ea30de7a1e4f1cdea14dd9a719960535e257a9e40e98dbb1a5870226"), Romset::MK1, RomLocation::ROM2},
     // R15209276 (WAVE A)
     {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), Romset::MK1, RomLocation::WAVEROM1},
@@ -330,12 +347,10 @@ static constexpr KnownHash ROM_HASHES[] = {
     // SC-55 (v1.10)
     ///////////////////////////////////////////////////////////////////////////
 
-    // TODO: missing hashes for this romset
-
     // R15199736 (H8/532 mcu)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::MK1, RomLocation::ROM1},
+    {ToDigest("2fe88ec39f3ef4b1de8cdf74527419467975c47f7aacfcd07605e01d54bd89b5"), Romset::MK1, RomLocation::ROM1},
     // R15209275 (H8/532 extra code)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::MK1, RomLocation::ROM2},
+    {ToDigest("ec064d6c4fc70ec990911089d966043cb819fba0e26e6f6afdd0a05e5301b91b"), Romset::MK1, RomLocation::ROM2},
     // R15209276 (WAVE A)
     {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), Romset::MK1, RomLocation::WAVEROM1},
     // R15209277 (WAVE B)
@@ -349,7 +364,7 @@ static constexpr KnownHash ROM_HASHES[] = {
 
     // R15199778 (H8/532 mcu)
     {ToDigest("7e1bacd1d7c62ed66e465ba05597dcd60dfc13fc23de0287fdbce6cf906c6544"), Romset::MK1, RomLocation::ROM1},
-    // R1544925800 (H8/532 extra code)?
+    // R15209337 (H8/532 extra code)
     {ToDigest("22ce6ca59e6332143b335525e81fab501ea6fccce4b7e2f3bfc2cc8bf6612ff6"), Romset::MK1, RomLocation::ROM2},
     // R15209276 (WAVE A)
     {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), Romset::MK1, RomLocation::WAVEROM1},
@@ -393,7 +408,7 @@ static constexpr KnownHash ROM_HASHES[] = {
     ///////////////////////////////////////////////////////////////////////////
 
     // R15199774 (H8/532 mcu)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::CM300, RomLocation::ROM1},
+    {ToDigest("72ed35481efbf25b3c492b83183655d17a3b266ecb30ffbc6dc977e6a8d261b2"), Romset::CM300, RomLocation::ROM1},
     // R15279809 (H8/532 extra code)
     {ToDigest("0283d32e6993a0265710c4206463deb937b0c3a4819b69f471a0eca5865719f9"), Romset::CM300, RomLocation::ROM2},
     // R15279806 (WAVE A)
@@ -408,7 +423,7 @@ static constexpr KnownHash ROM_HASHES[] = {
     ///////////////////////////////////////////////////////////////////////////
 
     // R15199774 (H8/532 mcu)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::CM300, RomLocation::ROM1},
+    {ToDigest("72ed35481efbf25b3c492b83183655d17a3b266ecb30ffbc6dc977e6a8d261b2"), Romset::CM300, RomLocation::ROM1},
     // R15279812 (H8/532 extra code)
     {ToDigest("fef1acb1969525d66238be5e7811108919b07a4df5fbab656ad084966373483f"), Romset::CM300, RomLocation::ROM2},
     // R15279806 (WAVE A)
@@ -434,34 +449,51 @@ static constexpr KnownHash ROM_HASHES[] = {
     {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), Romset::CM300, RomLocation::WAVEROM3},
 
     ///////////////////////////////////////////////////////////////////////////
-    // JV-880 (v1.0.0)
+    // JV-880 (v1.0.0 or v1.00)
     ///////////////////////////////////////////////////////////////////////////
+
+    // TODO: missing JV-880 optional ROMs
 
     // R15199810 (H8/532 mcu)
     {ToDigest("aabfcf883b29060198566440205f2fae1ce689043ea0fc7074842aaa4fd4823e"), Romset::JV880, RomLocation::ROM1},
     // R15209386 (H8/532 extra code)
+    {ToDigest("11852e60ff597633c754c5441c1e3e06793bcd951fcea2c4969ac3041d130fce"), Romset::JV880, RomLocation::ROM2},
+    // R15209312 (WAVE A)
+    {ToDigest("aa3101a76d57992246efeda282a2cb0c0f8fdb441c2eed2aa0b0fad4d81f3ad4"), Romset::JV880, RomLocation::WAVEROM1},
+    // R15209313 (WAVE B)
+    {ToDigest("a7b50bb47734ee9117fa16df1f257990a9a1a0b5ed420337ae4310eb80df75c8"), Romset::JV880, RomLocation::WAVEROM2},
+    // R00000000 (PCM card)
+    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::JV880, RomLocation::WAVEROM_CARD},
+    // R00000000 (Expansion PCB)
+    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::JV880, RomLocation::WAVEROM_EXP},
+
+    ///////////////////////////////////////////////////////////////////////////
+    // JV-880 (v1.0.1 or v1.01)
+    ///////////////////////////////////////////////////////////////////////////
+
+    // TODO: missing JV-880 optional ROMs
+
+    // R15199810 (H8/532 mcu)
+    {ToDigest("aabfcf883b29060198566440205f2fae1ce689043ea0fc7074842aaa4fd4823e"), Romset::JV880, RomLocation::ROM1},
+    // R15209481 (H8/532 extra code)
     {ToDigest("ed437f1bc75cc558f174707bcfeb45d5e03483efd9bfd0a382ca57c0edb2a40c"), Romset::JV880, RomLocation::ROM2},
     // R15209312 (WAVE A)
     {ToDigest("aa3101a76d57992246efeda282a2cb0c0f8fdb441c2eed2aa0b0fad4d81f3ad4"), Romset::JV880, RomLocation::WAVEROM1},
     // R15209313 (WAVE B)
     {ToDigest("a7b50bb47734ee9117fa16df1f257990a9a1a0b5ed420337ae4310eb80df75c8"), Romset::JV880, RomLocation::WAVEROM2},
-    // R00000000 (placeholder)
+    // R00000000 (PCM card)
     {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::JV880, RomLocation::WAVEROM_CARD},
-    // R00000000 (placeholder)
+    // R00000000 (Expansion PCB)
     {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::JV880, RomLocation::WAVEROM_EXP},
-
-    // TODO: missing jv880 optional roms
 
     ///////////////////////////////////////////////////////////////////////////
     // SCB-55/RLP-3194
     ///////////////////////////////////////////////////////////////////////////
 
-    // TODO: missing hashes for this romset
-
     // R15199827 (H8/532 mcu)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::SCB55, RomLocation::ROM1},
+    {ToDigest("00df835d3f97fc8b0059db63f36d608eec2bfd1f51ad54eb5af52c868c1111b1"), Romset::SCB55, RomLocation::ROM1},
     // R15279828 (H8/532 extra code)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::SCB55, RomLocation::ROM2},
+    {ToDigest("541be4d0b1ef0d07bb042ba67ffd099c8a5d746aac4cd24ce8842c034379f213"), Romset::SCB55, RomLocation::ROM2},
     // R15209359 (WAVE 16M)
     {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), Romset::SCB55, RomLocation::WAVEROM1},
     // R15279813 (WAVE 8M)
@@ -472,14 +504,12 @@ static constexpr KnownHash ROM_HASHES[] = {
     // RLP-3237
     ///////////////////////////////////////////////////////////////////////////
 
-    // TODO: missing hashes for this romset
-
     // R15199827 (H8/532 mcu)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::RLP3237, RomLocation::ROM1},
+    {ToDigest("00df835d3f97fc8b0059db63f36d608eec2bfd1f51ad54eb5af52c868c1111b1"), Romset::RLP3237, RomLocation::ROM1},
     // R15209486 (H8/532 extra code)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::RLP3237, RomLocation::ROM2},
+    {ToDigest("e0a3d6d9b05e82374a0d289901273ce560ce1ead86459c75f844158b32d204a9"), Romset::RLP3237, RomLocation::ROM2},
     // R15279824 (WAVE 16M)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::RLP3237, RomLocation::WAVEROM1},
+    {ToDigest("dae2a8bc0fd3bcaf3f5e3ab6c4c6fd30e2663bf26ca17afe52924874c0afc4e2"), Romset::RLP3237, RomLocation::WAVEROM1},
 
     ///////////////////////////////////////////////////////////////////////////
     // SC-155 (rev 1)
@@ -500,7 +530,7 @@ static constexpr KnownHash ROM_HASHES[] = {
     // SC-155 (rev 2)
     ///////////////////////////////////////////////////////////////////////////
 
-    // TODO: missing hashes for this romset
+    // TODO: missing hashes for this ROM set
 
     // R15199799 (H8/532 mcu)
     {ToDigest("24a65c97cdbaa847d6f59193523ce63c73394b4b693a6517ee79441f2fb8a3ee"), Romset::SC155, RomLocation::ROM1},
@@ -514,10 +544,10 @@ static constexpr KnownHash ROM_HASHES[] = {
     {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), Romset::SC155, RomLocation::WAVEROM3},
 
     ///////////////////////////////////////////////////////////////////////////
-    // Extra/modified roms
+    // Extra/modified ROMs
     ///////////////////////////////////////////////////////////////////////////
 
-    // CTF patched roms from https://github.com/shingo45endo/sc55mk2-ctf-patcher
+    // CTF patched ROMs from https://github.com/shingo45endo/sc55mk2-ctf-patcher
 
     // Tone: Strict SC-55 | Drum: SC-55 v1.21 or earlier
     {ToDigest("64f8c9daf1021cf86ea4ddf03a29b81b5ea0c18e74f462833023436388bb9dc4"), Romset::MK2, RomLocation::ROM2},
@@ -545,7 +575,7 @@ bool DetectRomsetsByHash(const std::filesystem::path& base_path,
 
     if (ec)
     {
-//        fprintf(stderr, "Failed to walk rom directory: %s\n", ec.message().c_str());
+        //fprintf(stderr, "Failed to walk rom directory: %s\n", ec.message().c_str());
         return false;
     }
 
@@ -556,10 +586,10 @@ bool DetectRomsetsByHash(const std::filesystem::path& base_path,
         const bool is_file = dir_iter->is_regular_file(ec);
         if (ec)
         {
-//            fprintf(stderr,
-//                    "Failed to check file type of `%s`: %s\n",
-//                    dir_iter->path().generic_string().c_str(),
-//                    ec.message().c_str());
+            //fprintf(stderr,
+            //        "Failed to check file type of `%s`: %s\n",
+            //        dir_iter->path().generic_string().c_str(),
+            //        ec.message().c_str());
             return false;
         }
 
@@ -568,7 +598,7 @@ bool DetectRomsetsByHash(const std::filesystem::path& base_path,
             dir_iter.increment(ec);
             if (ec)
             {
-//                fprintf(stderr, "Failed to get next file: %s\n", ec.message().c_str());
+                //fprintf(stderr, "Failed to get next file: %s\n", ec.message().c_str());
                 return false;
             }
             continue;
@@ -577,10 +607,10 @@ bool DetectRomsetsByHash(const std::filesystem::path& base_path,
         const uintmax_t file_size = dir_iter->file_size(ec);
         if (ec)
         {
-//            printf(stderr,
-//                    "Failed to get file size of `%s`: %s\n",
-//                    dir_iter->path().generic_string().c_str(),
-//                    ec.message().c_str());
+            //fprintf(stderr,
+            //        "Failed to get file size of `%s`: %s\n",
+            //        dir_iter->path().generic_string().c_str(),
+            //        ec.message().c_str());
             return false;
         }
 
@@ -590,7 +620,7 @@ bool DetectRomsetsByHash(const std::filesystem::path& base_path,
             dir_iter.increment(ec);
             if (ec)
             {
-//                fprintf(stderr, "Failed to get next file: %s\n", ec.message().c_str());
+                //fprintf(stderr, "Failed to get next file: %s\n", ec.message().c_str());
                 return false;
             }
             continue;
@@ -602,7 +632,7 @@ bool DetectRomsetsByHash(const std::filesystem::path& base_path,
         SHA256Digest  digest_bytes;
 
         SHA256Reset(&ctx);
-        SHA256Input(&ctx, buffer.data(), buffer.size());
+        SHA256Input(&ctx, buffer.data(), (unsigned int)buffer.size());
         SHA256Result(&ctx, digest_bytes.data());
 
         for (const auto& known : ROM_HASHES)
@@ -631,7 +661,7 @@ bool DetectRomsetsByHash(const std::filesystem::path& base_path,
         dir_iter.increment(ec);
         if (ec)
         {
-//            fprintf(stderr, "Failed to get next file: %s\n", ec.message().c_str());
+            //fprintf(stderr, "Failed to get next file: %s\n", ec.message().c_str());
             return false;
         }
     }

--- a/src/nuked-sc55/backend/submcu.cpp
+++ b/src/nuked-sc55/backend/submcu.cpp
@@ -114,7 +114,7 @@ uint8_t SM_Read(submcu_t& sm, uint16_t address)
             }
             case SM_DEV_UART2_MODE_STATUS:
             {
-                uint8_t ret = sm.uart_rx_gotbyte << 1;
+                uint8_t ret = (uint8_t)(sm.uart_rx_gotbyte << 1);
                 ret |= 5;
                 return ret;
             }
@@ -139,7 +139,7 @@ uint8_t SM_Read(submcu_t& sm, uint16_t address)
     {
         address &= 0xff;
         if (sm.device_mode[SM_DEV_RAM_DIR] & (1<<(address>>5)))
-            sm.access[address>>3] &= ~(1<<(address&7));
+            sm.access[address>>3] &= (uint8_t)(~(1<<(address&7)));
         return sm.shared_ram[address];
     }
     else
@@ -255,7 +255,7 @@ uint8_t SM_SysRead(submcu_t& sm, uint32_t address)
     if (address < 0xc0)
     {
         if ((sm.device_mode[SM_DEV_RAM_DIR] & (1<<(address>>5))) == 0)
-            sm.access[address>>3] &= ~(1<<(address&7));
+            sm.access[address>>3] &= (uint8_t)(~(1<<(address&7)));
         return sm.shared_ram[address];
     }
     else if (address >= 0xf8 && address < 0xfc)
@@ -293,17 +293,17 @@ uint8_t SM_SysRead(submcu_t& sm, uint32_t address)
 
 uint16_t SM_GetVectorAddress(submcu_t& sm, uint32_t vector)
 {
-    uint16_t pc = SM_Read(sm, 0x1fec + vector * 2);
-    pc |= SM_Read(sm, 0x1fec + vector * 2 + 1) << 8;
+    uint16_t pc = SM_Read(sm, (uint16_t)(0x1fec + vector * 2));
+    pc |= (uint16_t)(SM_Read(sm, (uint16_t)(0x1fec + vector * 2 + 1)) << 8);
     return pc;
 }
 
 void SM_SetStatus(submcu_t& sm, uint32_t condition, uint32_t mask)
 {
     if (condition)
-        sm.sr |= mask;
+        sm.sr |= (uint8_t)mask;
     else
-        sm.sr &= ~mask;
+        sm.sr &= (uint8_t)(~mask);
 }
 
 void SM_Init(submcu_t& sm, mcu_t& mcu)
@@ -333,14 +333,14 @@ uint8_t SM_ReadAdvance(submcu_t& sm)
 uint16_t SM_ReadAdvance16(submcu_t& sm)
 {
     uint16_t word = SM_ReadAdvance(sm);
-    word |= SM_ReadAdvance(sm) << 8;
+    word |= (uint16_t)(SM_ReadAdvance(sm) << 8);
     return word;
 }
 
 uint16_t SM_Read16(submcu_t& sm, uint16_t address)
 {
     uint16_t word = SM_Read(sm, address);
-    word |= SM_Read(sm, address) << 8;
+    word |= (uint16_t)(SM_Read(sm, address) << 8);
     return word;
 }
 
@@ -510,12 +510,12 @@ void SM_Opcode_BBC_BBS(submcu_t& sm, uint8_t opcode)
         val = SM_Read(sm, SM_ReadAdvance(sm));
     }
 
-    int8_t diff = SM_ReadAdvance(sm);
+    int8_t diff = (int8_t)SM_ReadAdvance(sm);
 
     int32_t set = (val >> bit) & 1;
 
     if (set != type)
-        sm.pc += diff;
+        sm.pc += (uint16_t)diff;
 }
 
 void SM_Opcode_CPX(submcu_t& sm, uint8_t opcode) // e0, e4, ec
@@ -535,7 +535,7 @@ void SM_Opcode_CPX(submcu_t& sm, uint8_t opcode) // e0, e4, ec
     }
     int diff = sm.x - operand;
     SM_SetStatus(sm, (diff & 0x100) == 0, SM_STATUS_C);
-    SM_Update_NZ(sm, diff & 0xff);
+    SM_Update_NZ(sm, (uint8_t)diff);
 }
 
 void SM_Opcode_CPY(submcu_t& sm, uint8_t opcode) // c0, c4, cc
@@ -555,31 +555,31 @@ void SM_Opcode_CPY(submcu_t& sm, uint8_t opcode) // c0, c4, cc
     }
     int diff = sm.y - operand;
     SM_SetStatus(sm, (diff & 0x100) == 0, SM_STATUS_C);
-    SM_Update_NZ(sm, diff & 0xff);
+    SM_Update_NZ(sm, (uint8_t)diff);
 }
 
 void SM_Opcode_BEQ(submcu_t& sm, uint8_t opcode) // f0
 {
     (void)opcode;
-    int8_t diff = SM_ReadAdvance(sm);
+    int8_t diff = (int8_t)SM_ReadAdvance(sm);
     if ((sm.sr & SM_STATUS_Z) != 0)
-        sm.pc += diff;
+        sm.pc += (uint16_t)diff;
 }
 
 void SM_Opcode_BCC(submcu_t& sm, uint8_t opcode) // 90
 {
     (void)opcode;
-    int8_t diff = SM_ReadAdvance(sm);
+    int8_t diff = (int8_t)SM_ReadAdvance(sm);
     if ((sm.sr & SM_STATUS_C) == 0)
-        sm.pc += diff;
+        sm.pc += (uint16_t)diff;
 }
 
 void SM_Opcode_BCS(submcu_t& sm, uint8_t opcode) // b0
 {
     (void)opcode;
-    int8_t diff = SM_ReadAdvance(sm);
+    int8_t diff = (int8_t)SM_ReadAdvance(sm);
     if ((sm.sr & SM_STATUS_C) != 0)
-        sm.pc += diff;
+        sm.pc += (uint16_t)diff;
 }
 
 void SM_Opcode_LDM(submcu_t& sm, uint8_t opcode) // 3c
@@ -669,7 +669,7 @@ void SM_Opcode_SEB_CLB(submcu_t& sm, uint8_t opcode)
     }
 
     if (type)
-        val &= ~(1 << bit);
+        val &= (uint8_t)(~(1 << bit));
     else
         val |= 1 << bit;
 
@@ -688,7 +688,7 @@ void SM_Opcode_RTI(submcu_t& sm, uint8_t opcode) // 40
     (void)opcode;
     sm.sr = SM_PopStack(sm);
     sm.pc = SM_PopStack(sm);
-    sm.pc |= SM_PopStack(sm) << 8;
+    sm.pc |= (uint16_t)(SM_PopStack(sm) << 8);
 }
 
 void SM_Opcode_PLA(submcu_t& sm, uint8_t opcode) // 68
@@ -701,8 +701,8 @@ void SM_Opcode_PLA(submcu_t& sm, uint8_t opcode) // 68
 void SM_Opcode_BRA(submcu_t& sm, uint8_t opcode) // 80
 {
     (void)opcode;
-    int8_t disp = SM_ReadAdvance(sm);
-    sm.pc += disp;
+    int8_t disp = (int8_t)SM_ReadAdvance(sm);
+    sm.pc += (uint16_t)disp;
 }
 
 void SM_Opcode_JSR(submcu_t& sm, uint8_t opcode) // 20, 02, 22
@@ -721,8 +721,8 @@ void SM_Opcode_JSR(submcu_t& sm, uint8_t opcode) // 20, 02, 22
             break;
     }
 
-    SM_PushStack(sm, sm.pc >> 8);
-    SM_PushStack(sm, sm.pc & 0xff);
+    SM_PushStack(sm, (uint8_t)(sm.pc >> 8));
+    SM_PushStack(sm, (uint8_t)sm.pc);
     sm.pc = newpc;
 }
 
@@ -758,22 +758,22 @@ void SM_Opcode_CMP(submcu_t& sm, uint8_t opcode) // c9, c5, d5, cd, dd, d9, c1, 
     }
     int diff = sm.a - operand;
     SM_SetStatus(sm, (diff & 0x100) == 0, SM_STATUS_C);
-    SM_Update_NZ(sm, diff & 0xff);
+    SM_Update_NZ(sm, (uint8_t)diff);
 }
 
 void SM_Opcode_BNE(submcu_t& sm, uint8_t opcode) // d0
 {
     (void)opcode;
-    int8_t diff = SM_ReadAdvance(sm);
+    int8_t diff = (int8_t)SM_ReadAdvance(sm);
     if ((sm.sr & SM_STATUS_Z) == 0)
-        sm.pc += diff;
+        sm.pc += (uint16_t)diff;
 }
 
 void SM_Opcode_RTS(submcu_t& sm, uint8_t opcode) // 60
 {
     (void)opcode;
     sm.pc = SM_PopStack(sm);
-    sm.pc |= SM_PopStack(sm) << 8;
+    sm.pc |= (uint16_t)(SM_PopStack(sm) << 8);
 }
 
 void SM_Opcode_JMP(submcu_t& sm, uint8_t opcode) // 4c, 6c, b2
@@ -939,9 +939,9 @@ void SM_Opcode_NOP(submcu_t& sm, uint8_t opcode) // EA
 void SM_Opcode_BPL(submcu_t& sm, uint8_t opcode) // 10
 {
     (void)opcode;
-    int8_t diff = SM_ReadAdvance(sm);
+    int8_t diff = (int8_t)SM_ReadAdvance(sm);
     if ((sm.sr & SM_STATUS_N) == 0)
-        sm.pc += diff;
+        sm.pc += (uint16_t)diff;
 }
 
 void SM_Opcode_CLC(submcu_t& sm, uint8_t opcode) // 18
@@ -1299,8 +1299,8 @@ void (*SM_Opcode_Table[256])(submcu_t& sm, uint8_t opcode)
 
 void SM_StartVector(submcu_t& sm, uint32_t vector)
 {
-    SM_PushStack(sm, sm.pc >> 8);
-    SM_PushStack(sm, sm.pc & 0xff);
+    SM_PushStack(sm, (uint8_t)(sm.pc >> 8));
+    SM_PushStack(sm, (uint8_t)sm.pc);
     SM_PushStack(sm, sm.sr);
 
     sm.sr |= SM_STATUS_I;

--- a/src/nuked-sc55/common/rom_loader.cpp
+++ b/src/nuked-sc55/common/rom_loader.cpp
@@ -43,7 +43,7 @@ LoadRomsetError LoadRomset(AllRomsetInfo&               romset_info,
             return LoadRomsetError::InvalidRomsetName;
         }
 
-        // When the user specifies a romset, we can speed up the loading process a bit.
+        // When the user specifies a ROM set, we can speed up the loading process a bit.
         RomLocationSet desired{};
         desired[(size_t)result.romset] = true;
 


### PR DESCRIPTION
Synchronized the backend of the Nuked-SC55 repository to the latest commit (0be4ab0 as of this date).

Notably, it includes additional ROM hashes and cleans up a large number of build warnings. I have personally done additional due diligence on the hashes so this list is more comprehensive than any of the sources for this plugin.

Note that this PR is "incomplete" in that the CLAP plugin does not build without additional (minor) changes. However, split the pull requests to allow for easier review.