### PR TITLE
Add Roland SC-55 v1.10 plugin support

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,7 +35,7 @@
         "VCPKG_TARGET_TRIPLET": "x64-windows-static-md",
         "VCPKG_HOST_TRIPLET": "x64-windows"
       }
-      },
+    },
     {
       "name": "release-windows-x64",
       "inherits": [ "base-vcpkg" ],
@@ -50,7 +50,7 @@
         "VCPKG_TARGET_TRIPLET": "x64-windows-static-md",
         "VCPKG_HOST_TRIPLET": "x64-windows"
       }
-      },
+    },
     {
       "name": "debug-windows-arm64",
       "inherits": [ "base-vcpkg" ],

--- a/src/nuked_sc55.cpp
+++ b/src/nuked_sc55.cpp
@@ -60,8 +60,6 @@ static void log_shutdown() {}
     #define log(...)
 #endif
 
-
-
 //----------------------------------------------------------------------------
 
 // Get the environment variable value from the provided name, 
@@ -177,11 +175,13 @@ bool NukedSc55::Init(const clap_plugin* _plugin_instance)
     }
 
     auto rom_paths = GetRomBasePaths();
-    for (auto rom_path : rom_paths) {
-        auto romset   = "mk1";
+    for (const auto& base_path : rom_paths) {
+        auto rom_path = base_path;
+        auto romset = "mk1";
 
         switch (model) {
         case Model::Sc55_v1_00: rom_path /= "SC-55-v1.00"; break;
+        case Model::Sc55_v1_10: rom_path /= "SC-55-v1.10"; break;
         case Model::Sc55_v1_20: rom_path /= "SC-55-v1.20"; break;
         case Model::Sc55_v1_21: rom_path /= "SC-55-v1.21"; break;
         case Model::Sc55_v2_00: rom_path /= "SC-55-v2.00"; break;
@@ -209,7 +209,7 @@ bool NukedSc55::Init(const clap_plugin* _plugin_instance)
             return false;
         }
         return true;
-        }
+    }
     log("Init failed, tried all ROM directories");
     emu.reset(nullptr);
     return false;
@@ -247,7 +247,7 @@ bool NukedSc55::Activate(const double requested_sample_rate,
         max_frame_count);
 
     emu->Reset();
-    emu->GetPCM().disable_oversampling = true;
+    emu->GetPCM().enable_oversampling = false;
     emu->PostSystemReset(EMU_SystemReset::GS_RESET);
 
     // Speed up the devices' bootup delay

--- a/src/nuked_sc55.h
+++ b/src/nuked_sc55.h
@@ -11,7 +11,7 @@
 
 class NukedSc55 {
 public:
-    enum class Model { Sc55_v1_00, Sc55_v1_20, Sc55_v1_21, Sc55_v2_00, Sc55mk2_v1_01 };
+    enum class Model { Sc55_v1_00, Sc55_v1_10, Sc55_v1_20, Sc55_v1_21, Sc55_v2_00, Sc55mk2_v1_01 };
 
     // Init/shutdown
     NukedSc55(const clap_plugin_t plugin_class, const clap_host_t* host,

--- a/src/nuked_sc55_win32.manifest
+++ b/src/nuked_sc55_win32.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity type="win32" name="net.johnnovak.nuked_sc55_clap" version="6.0.0.0"/>
+  <assemblyIdentity type="win32" name="net.johnnovak.nuked_sc55_clap" version="0.10.0.0"/>
   <application>
     <windowsSettings>
       <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -9,7 +9,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 // Number of plugins in this dynamic library
-constexpr auto NumPlugins = 5;
+constexpr auto NumPlugins = 6;
 
 constexpr auto Vendor  = "John Novak";
 constexpr auto Url     = "https://github.com/johnnovak/Nuked-SC55-CLAP";
@@ -30,6 +30,18 @@ static const clap_plugin_descriptor_t plugin_descriptor_sc55_v1_00 = {
     .support_url  = Url,
     .version      = Version,
     .description  = "Roland SC-55 v1.00 MIDI sound module emulation",
+    .features     = Features};
+
+static const clap_plugin_descriptor_t plugin_descriptor_sc55_v1_10 = {
+    .clap_version = CLAP_VERSION_INIT,
+    .id           = "net.johnnovak.nuked_sc55_clap.sc55_v1_10",
+    .name         = "Nuked SC-55 — Roland SC-55 v1.10",
+    .vendor       = Vendor,
+    .url          = Url,
+    .manual_url   = Url,
+    .support_url  = Url,
+    .version      = Version,
+    .description  = "Roland SC-55 v1.10 MIDI sound module emulation",
     .features     = Features};
 
 static const clap_plugin_descriptor_t plugin_descriptor_sc55_v1_20 = {
@@ -174,12 +186,57 @@ static const clap_plugin_t my_plugin_class_sc55_v1_00 = {
         return the_plugin->Init(plugin);
     },
 
-    .destroy =
-        [](const clap_plugin* plugin) {
-            auto the_plugin = (NukedSc55*)plugin->plugin_data;
-            the_plugin->Shutdown();
-            delete the_plugin;
-        },
+    .destroy = [](const clap_plugin* plugin) {
+        auto the_plugin = (NukedSc55*)plugin->plugin_data;
+        the_plugin->Shutdown();
+        delete the_plugin;
+    },
+
+    .activate = [](const clap_plugin* plugin, double sample_rate,
+                   uint32_t min_frame_count, uint32_t max_frame_count) -> bool {
+        auto the_plugin = (NukedSc55*)plugin->plugin_data;
+        return the_plugin->Activate(sample_rate, min_frame_count, max_frame_count);
+    },
+
+    .deactivate = [](const clap_plugin* plugin) {},
+
+    .start_processing = [](const clap_plugin* plugin) -> bool { return true; },
+
+    .stop_processing = [](const clap_plugin* plugin) {},
+
+    .reset = [](const clap_plugin* plugin) {},
+
+    .process = [](const clap_plugin* plugin,
+                  const clap_process_t* process) -> clap_process_status {
+        auto the_plugin = (NukedSc55*)plugin->plugin_data;
+        return the_plugin->Process(process);
+    },
+
+    .get_extension = [](const clap_plugin* plugin, const char* id) -> const void* {
+        return get_extension(plugin, id);
+    },
+
+    .on_main_thread = [](const clap_plugin* plugin) {}};
+
+//----------------------------------------------------------------------------
+// SC-55 v1.10
+//----------------------------------------------------------------------------
+static const clap_plugin_t my_plugin_class_sc55_v1_10 = {
+
+    .desc = &plugin_descriptor_sc55_v1_10,
+
+    .plugin_data = nullptr,
+
+    .init = [](const clap_plugin* plugin) -> bool {
+        auto the_plugin = (NukedSc55*)plugin->plugin_data;
+        return the_plugin->Init(plugin);
+    },
+
+    .destroy = [](const clap_plugin* plugin) {
+        auto the_plugin = (NukedSc55*)plugin->plugin_data;
+        the_plugin->Shutdown();
+        delete the_plugin;
+    },
 
     .activate = [](const clap_plugin* plugin, double sample_rate,
                    uint32_t min_frame_count, uint32_t max_frame_count) -> bool {
@@ -221,12 +278,11 @@ static const clap_plugin_t my_plugin_class_sc55_v1_20 = {
         return the_plugin->Init(plugin);
     },
 
-    .destroy =
-        [](const clap_plugin* plugin) {
-            auto the_plugin = (NukedSc55*)plugin->plugin_data;
-            the_plugin->Shutdown();
-            delete the_plugin;
-        },
+    .destroy = [](const clap_plugin* plugin) {
+        auto the_plugin = (NukedSc55*)plugin->plugin_data;
+        the_plugin->Shutdown();
+        delete the_plugin;
+    },
 
     .activate = [](const clap_plugin* plugin, double sample_rate,
                    uint32_t min_frame_count, uint32_t max_frame_count) -> bool {
@@ -268,12 +324,11 @@ static const clap_plugin_t my_plugin_class_sc55_v1_21 = {
         return the_plugin->Init(plugin);
     },
 
-    .destroy =
-        [](const clap_plugin* plugin) {
-            auto the_plugin = (NukedSc55*)plugin->plugin_data;
-            the_plugin->Shutdown();
-            delete the_plugin;
-        },
+    .destroy = [](const clap_plugin* plugin) {
+        auto the_plugin = (NukedSc55*)plugin->plugin_data;
+        the_plugin->Shutdown();
+        delete the_plugin;
+    },
 
     .activate = [](const clap_plugin* plugin, double sample_rate,
                    uint32_t min_frame_count, uint32_t max_frame_count) -> bool {
@@ -315,12 +370,11 @@ static const clap_plugin_t my_plugin_class_sc55_v2_00 = {
         return the_plugin->Init(plugin);
     },
 
-    .destroy =
-        [](const clap_plugin* plugin) {
-            auto the_plugin = (NukedSc55*)plugin->plugin_data;
-            the_plugin->Shutdown();
-            delete the_plugin;
-        },
+    .destroy = [](const clap_plugin* plugin) {
+        auto the_plugin = (NukedSc55*)plugin->plugin_data;
+        the_plugin->Shutdown();
+        delete the_plugin;
+    },
 
     .activate = [](const clap_plugin* plugin, double sample_rate,
                    uint32_t min_frame_count, uint32_t max_frame_count) -> bool {
@@ -362,12 +416,11 @@ static const clap_plugin_t my_plugin_class_sc55mk2_v1_01 = {
         return the_plugin->Init(plugin);
     },
 
-    .destroy =
-        [](const clap_plugin* plugin) {
-            auto the_plugin = (NukedSc55*)plugin->plugin_data;
-            the_plugin->Shutdown();
-            delete the_plugin;
-        },
+    .destroy = [](const clap_plugin* plugin) {
+        auto the_plugin = (NukedSc55*)plugin->plugin_data;
+        the_plugin->Shutdown();
+        delete the_plugin;
+    },
 
     .activate = [](const clap_plugin* plugin, double sample_rate,
                    uint32_t min_frame_count, uint32_t max_frame_count) -> bool {
@@ -411,15 +464,18 @@ static const clap_plugin_factory_t plugin_factory = {
             return &plugin_descriptor_sc55_v1_00;
 
         } else if (index == 1) {
-            return &plugin_descriptor_sc55_v1_20;
+            return &plugin_descriptor_sc55_v1_10;
 
         } else if (index == 2) {
-            return &plugin_descriptor_sc55_v1_21;
+            return &plugin_descriptor_sc55_v1_20;
 
         } else if (index == 3) {
-            return &plugin_descriptor_sc55_v2_00;
+            return &plugin_descriptor_sc55_v1_21;
 
         } else if (index == 4) {
+            return &plugin_descriptor_sc55_v2_00;
+
+        } else if (index == 5) {
             return &plugin_descriptor_sc55mk2_v1_01;
 
         } else {
@@ -439,6 +495,11 @@ static const clap_plugin_factory_t plugin_factory = {
             the_plugin = new NukedSc55(my_plugin_class_sc55_v1_00,
                                        host,
                                        NukedSc55::Model::Sc55_v1_00);
+
+        } else if (strcmp(plugin_id, plugin_descriptor_sc55_v1_10.id) == 0) {
+            the_plugin = new NukedSc55(my_plugin_class_sc55_v1_10,
+                                       host,
+                                       NukedSc55::Model::Sc55_v1_10);
 
         } else if (strcmp(plugin_id, plugin_descriptor_sc55_v1_20.id) == 0) {
             the_plugin = new NukedSc55(my_plugin_class_sc55_v1_20,


### PR DESCRIPTION
Implements #21 and complements #25.

This request includes the plugin changes needed to utilize the Roland SC-55 v1.10 ROMs identified by the respective hashes.

These changes through its resulting plugin were tested using the Windows x64 versions of DOSBox Staging (0.83 alphas) and of foo_midi (3.2.3) in foobar2000.