### PR TITLE
Sync vendored Nuked-SC55 backend to jcmoyer/Nuked-SC55 master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,10 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 #configure_file(config.h.in config.h)
 
 add_library(Nuked-SC55-CLAP MODULE
+    src/nuked-sc55/backend/diagnostics.cpp
     src/nuked-sc55/backend/emu.cpp
+    src/nuked-sc55/backend/file_hashing.cpp
+    src/nuked-sc55/backend/file_io.cpp
     src/nuked-sc55/backend/lcd.cpp
     src/nuked-sc55/backend/mcu.cpp
     src/nuked-sc55/backend/mcu_interrupt.cpp
@@ -30,6 +33,7 @@ add_library(Nuked-SC55-CLAP MODULE
     src/nuked-sc55/backend/pcm.cpp
     src/nuked-sc55/backend/rom.cpp
     src/nuked-sc55/backend/rom_io.cpp
+    src/nuked-sc55/backend/standard_romsets.cpp
     src/nuked-sc55/backend/submcu.cpp
 
     src/nuked-sc55/backend/sha/sha224-256.c

--- a/src/nuked-sc55/backend/cast.h
+++ b/src/nuked-sc55/backend/cast.h
@@ -3,17 +3,19 @@
 #include <source_location>
 #include <utility>
 
+#include "diagnostics.h"
+
 template <typename R, typename T>
 [[nodiscard]]
 inline R RangeCast(T value, const std::source_location where = std::source_location::current())
 {
     if (!std::in_range<R>(value)) [[unlikely]]
     {
-        //fprintf(stderr,
-        //        "WARN: %s:%s:%d: Cast value out of range\n",
-        //        where.file_name(),
-        //        where.function_name(),
-        //        (int)where.line());
+        Diag_Printf(Diag_Category::Warning,
+                    "%s:%s:%d: Cast value out of range\n",
+                    where.file_name(),
+                    where.function_name(),
+                    (int)where.line());
     }
     return (R)value;
 }

--- a/src/nuked-sc55/backend/diagnostics.cpp
+++ b/src/nuked-sc55/backend/diagnostics.cpp
@@ -1,0 +1,51 @@
+#include "diagnostics.h"
+
+#include <cstdarg>
+#include <cstdio>
+
+static Diag_Callback Diag_CurrentCallback = Diag_DefaultCallback;
+
+const char* ToCString(Diag_Category category)
+{
+    switch (category)
+    {
+    case Diag_Category::Debug:
+        return "Debug";
+    case Diag_Category::Error:
+        return "Error";
+    case Diag_Category::Warning:
+        return "Warning";
+    }
+    return "unknown";
+}
+
+void Diag_DefaultCallback(Diag_Category category, std::string_view message)
+{
+    fprintf(stderr, "[%s] %.*s", ToCString(category), (int)message.size(), message.data());
+}
+
+void Diag_Printf(Diag_Category category, const char* format, ...)
+{
+    if (!Diag_CurrentCallback)
+    {
+        return;
+    }
+
+    // no message we print requires a larger buffer than this
+    char buf[1024] = {0};
+
+    va_list list;
+    va_start(list, format);
+    int len = vsnprintf(buf, sizeof(buf), format, list);
+    va_end(list);
+
+    if (len > 0)
+    {
+        Diag_CurrentCallback(category, std::string_view(buf, (size_t)len));
+    }
+}
+
+void Diag_SetCallback(Diag_Callback callback)
+{
+    Diag_CurrentCallback = callback;
+}

--- a/src/nuked-sc55/backend/diagnostics.h
+++ b/src/nuked-sc55/backend/diagnostics.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string_view>
+
+enum class Diag_Category
+{
+    Debug,
+    Error,
+    Warning,
+};
+
+const char* ToCString(Diag_Category category);
+
+using Diag_Callback = void(*)(Diag_Category category, std::string_view message);
+
+// The default callback handler which prints messages to `stderr`.
+void Diag_DefaultCallback(Diag_Category category, std::string_view message);
+
+// Sends a message from the backend to the callback.
+void Diag_Printf(Diag_Category category, const char* format, ...);
+
+// Sets the callback. This should be called before creating any emulators.
+// Callbacks can run on any thread that calls functions in the backend. If
+// there are multiple threads making such calls, the callback may need
+// synchronization.
+//
+// Passing `nullptr` will disable logging entirely.
+void Diag_SetCallback(Diag_Callback callback);

--- a/src/nuked-sc55/backend/emu.cpp
+++ b/src/nuked-sc55/backend/emu.cpp
@@ -31,8 +31,8 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include "emu.h"
+#include "diagnostics.h"
 #include "lcd.h"
 #include "mcu.h"
 #include "mcu_timer.h"
@@ -102,7 +102,7 @@ void Emulator::SetSampleCallback(mcu_sample_callback callback, void* userdata)
     m_mcu->sample_callback = callback;
 }
 
-bool Emulator::LoadRoms(Romset romset, const AllRomsetInfo& all_info, RomLocationSet* loaded)
+bool Emulator::LoadRoms(Romset romset, const RomsetInfo& info, RomLocationSet* loaded)
 {
     if (loaded)
     {
@@ -110,8 +110,6 @@ bool Emulator::LoadRoms(Romset romset, const AllRomsetInfo& all_info, RomLocatio
     }
 
     MCU_SetRomset(GetMCU(), romset);
-
-    const RomsetInfo& info = all_info.romsets[(size_t)romset];
 
     for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
     {
@@ -227,7 +225,7 @@ std::span<uint8_t> Emulator::MapBuffer(RomLocation location)
     case RomLocation::SMROM:
         return m_sm->rom;
     }
-    //fprintf(stderr, "FATAL: MapBuffer called with invalid location %d\n", (int)location);
+    Diag_Printf(Diag_Category::Error, "MapBuffer called with invalid location %d\n", (int)location);
     std::abort();
 }
 
@@ -237,10 +235,10 @@ bool Emulator::LoadRom(RomLocation location, std::span<const uint8_t> source)
 
     if (buffer.size() < source.size())
     {
-        //fprintf(stderr,
-        //        "FATAL: rom for %s is too large; max size is %d bytes\n",
-        //        ToCString(location),
-        //        (int)buffer.size());
+        Diag_Printf(Diag_Category::Error,
+                    "rom for %s is too large; max size is %d bytes\n",
+                    ToCString(location),
+                    (int)buffer.size());
         return false;
     }
 
@@ -248,7 +246,7 @@ bool Emulator::LoadRom(RomLocation location, std::span<const uint8_t> source)
     {
         if (!std::has_single_bit(source.size()))
         {
-            //fprintf(stderr, "FATAL: %s requires a power-of-2 size\n", ToCString(location));
+            Diag_Printf(Diag_Category::Error, "%s requires a power-of-2 size\n", ToCString(location));
             return false;
         }
         GetMCU().rom2_mask = (uint32_t)source.size() - 1;

--- a/src/nuked-sc55/backend/emu.h
+++ b/src/nuked-sc55/backend/emu.h
@@ -31,7 +31,6 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-
 #pragma once
 
 #include "lcd.h"
@@ -85,18 +84,17 @@ public:
 
     void SetSampleCallback(mcu_sample_callback callback, void* userdata);
 
-    // Loads roms from buffers referenced by `all_info`. If the slot for a rom in `all_info` has a non-empty `rom_data`,
-    // it will be loaded even if the romset doesn't require it.
+    // Loads roms from buffers referenced by `info`. If the slot for a rom in `info` has a non-empty `rom_data`, it
+    // will be loaded even if the romset doesn't require it.
     //
-    // It is unspecified whether or not the emulator will copy `rom_data`. `all_info` should outlive the emulator
-    // instance.
+    // It is unspecified whether or not the emulator will copy `rom_data`. `info` should outlive the emulator instance.
     //
     // For roms that were successfully loaded, this function will set their corresponding index in `loaded` to true if
     // `loaded` is non-null.
     //
-    // It is recommended to check if the romset has all the necessary roms by first calling
-    // `IsCompleteRomset(all_info, romset)`.
-    bool LoadRoms(Romset romset, const AllRomsetInfo& all_info, RomLocationSet* loaded = nullptr);
+    // It is recommended to check if the romset has all the necessary roms by first calling `IsCompleteRomset(info,
+    // romset)`.
+    bool LoadRoms(Romset romset, const RomsetInfo& info, RomLocationSet* loaded = nullptr);
 
     void PostMIDI(uint8_t data_byte);
     void PostMIDI(std::span<const uint8_t> data);

--- a/src/nuked-sc55/backend/file_hashing.cpp
+++ b/src/nuked-sc55/backend/file_hashing.cpp
@@ -1,0 +1,36 @@
+#include "file_hashing.h"
+
+bool HashedFileRegistry::AddFile(SHA256_Digest hash, HashedFile file)
+{
+    const size_t next_index = m_files.size();
+    auto [it, inserted]     = m_hash_map.emplace(std::make_pair(hash, next_index));
+    if (inserted)
+    {
+        m_files.emplace_back(std::move(file));
+        return true;
+    }
+    return false;
+}
+
+bool HashedFileRegistry::Contains(SHA256_Digest hash) const
+{
+    return m_hash_map.contains(hash);
+}
+
+const HashedFile* HashedFileRegistry::GetFile(SHA256_Digest hash) const
+{
+    const auto it = m_hash_map.find(hash);
+
+    if (it == m_hash_map.end())
+    {
+        return nullptr;
+    }
+
+    return &m_files[it->second];
+}
+
+void HashedFileRegistry::Purge()
+{
+    m_files.clear();
+    m_hash_map.clear();
+}

--- a/src/nuked-sc55/backend/file_hashing.h
+++ b/src/nuked-sc55/backend/file_hashing.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <concepts>
+#include <cstdint>
+#include <filesystem>
+#include <unordered_map>
+#include <vector>
+
+#include "diagnostics.h"
+#include "file_io.h"
+#include "sha256.h"
+
+// Contains the path and contents of a hashed file.
+struct HashedFile
+{
+    std::filesystem::path path;
+    std::vector<uint8_t>  data;
+};
+
+// Contains a list of hashed files and provides constant-time lookup by hash.
+class HashedFileRegistry
+{
+public:
+    // Returns true if the file was added, or false if there is already one
+    // with the same hash. Duplicate hashes is not an error condition.
+    bool AddFile(SHA256_Digest hash, HashedFile file);
+
+    bool Contains(SHA256_Digest hash) const;
+
+    // The returned pointer is invalidated when the registry is modified.
+    // This function returns `nullptr` when `hash` is not in the registry.
+    const HashedFile* GetFile(SHA256_Digest hash) const;
+
+    void Purge();
+
+private:
+    std::vector<HashedFile> m_files;
+    // SHA256 to index in `files`
+    std::unordered_map<SHA256_Digest, size_t> m_hash_map;
+};
+
+// If `filter` returns true for a file, it will be hashed; otherwise it will be skipped.
+template <std::invocable<const std::filesystem::directory_entry&> FileFilter>
+bool HashDirectoryFiles(const std::filesystem::path& dir_path, HashedFileRegistry& registry, FileFilter filter)
+{
+    using namespace std::filesystem;
+
+    // std::fileystem cannot guarantee exceptions won't be thrown even for the error code overloads
+    try
+    {
+        std::vector<uint8_t> buffer;
+
+        for (directory_iterator dir_iter(dir_path); dir_iter != directory_iterator{}; ++dir_iter)
+        {
+            if (!dir_iter->is_regular_file())
+            {
+                continue;
+            }
+
+            if (!filter(*dir_iter))
+            {
+                continue;
+            }
+
+            if (!FIO_ReadAllBytes(dir_iter->path(), buffer))
+            {
+                Diag_Printf(
+                    Diag_Category::Error, "Failed to read file: %s\n", dir_iter->path().generic_string().c_str());
+                return false;
+            }
+
+            SHA256_Digest digest_bytes;
+
+            if (!SHA256_HashBytes(buffer, digest_bytes))
+            {
+                return false;
+            }
+
+            registry.AddFile(digest_bytes,
+                             HashedFile{
+                                 .path = dir_iter->path(),
+                                 .data = std::move(buffer),
+                             });
+        }
+    }
+    catch (const std::exception& e)
+    {
+        Diag_Printf(Diag_Category::Error, "Failed to hash roms: %s\n", e.what());
+        return false;
+    }
+    return true;
+}

--- a/src/nuked-sc55/backend/file_io.cpp
+++ b/src/nuked-sc55/backend/file_io.cpp
@@ -1,0 +1,45 @@
+#include "file_io.h"
+
+#include <fstream>
+
+#include "cast.h"
+
+bool FIO_ReadAllBytes(const std::filesystem::path& filename, std::vector<uint8_t>& buffer)
+{
+    std::ifstream input(filename, std::ios::binary);
+
+    if (!input)
+    {
+        return false;
+    }
+
+    input.seekg(0, std::ios::end);
+    std::streamoff byte_count = input.tellg();
+    input.seekg(0, std::ios::beg);
+
+    buffer.resize(RangeCast<size_t>(byte_count));
+
+    input.read((char*)buffer.data(), RangeCast<std::streamsize>(byte_count));
+
+    return input.good();
+}
+
+bool FIO_ReadStreamExact(std::ifstream& s, void* into, std::streamsize byte_count)
+{
+    if (s.read((char*)into, byte_count))
+    {
+        return s.gcount() == byte_count;
+    }
+    return false;
+}
+
+bool FIO_ReadStreamExact(std::ifstream& s, std::span<uint8_t> into, std::streamsize byte_count)
+{
+    return FIO_ReadStreamExact(s, into.data(), byte_count);
+}
+
+std::streamsize FIO_ReadStreamUpTo(std::ifstream& s, void* into, std::streamsize byte_count)
+{
+    s.read((char*)into, byte_count);
+    return s.gcount();
+}

--- a/src/nuked-sc55/backend/file_io.h
+++ b/src/nuked-sc55/backend/file_io.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <filesystem>
+#include <iosfwd>
+#include <vector>
+#include <span>
+
+bool FIO_ReadAllBytes(const std::filesystem::path& filename, std::vector<uint8_t>& buffer);
+
+bool            FIO_ReadStreamExact(std::ifstream& s, void* into, std::streamsize byte_count);
+bool            FIO_ReadStreamExact(std::ifstream& s, std::span<uint8_t> into, std::streamsize byte_count);
+std::streamsize FIO_ReadStreamUpTo(std::ifstream& s, void* into, std::streamsize byte_count);

--- a/src/nuked-sc55/backend/mcu.cpp
+++ b/src/nuked-sc55/backend/mcu.cpp
@@ -31,8 +31,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include "mcu.h"
+
+#include "diagnostics.h"
 #include "lcd.h"
 #include "mcu_opcodes.h"
 #include "mcu_timer.h"
@@ -41,7 +42,7 @@
 
 void MCU_ErrorTrap(mcu_t& mcu)
 {
-    //fprintf(stderr, "%.2x %.4x\n", mcu.cp, mcu.pc);
+    Diag_Printf(Diag_Category::Debug, "%.2x %.4x\n", mcu.cp, mcu.pc);
 }
 
 uint8_t RCU_Read(void)
@@ -149,7 +150,7 @@ READ_RCU:
             goto READ_RCU;
     }
     // TODO: really unreachable? maybe addressed upstream later?
-    //fprintf(stderr, "PANIC: reached end of MCU_AnalogReadPin\n");
+    Diag_Printf(Diag_Category::Error, "reached end of MCU_AnalogReadPin\n");
     exit(1);
 }
 
@@ -497,7 +498,7 @@ uint8_t MCU_Read(mcu_t& mcu, uint32_t address)
                 }
                 else
                 {
-                    //fprintf(stderr, "Unknown read %x\n", address);
+                    Diag_Printf(Diag_Category::Debug, "Unknown read %x\n", address);
                     ret = 0xff;
                 }
                 //
@@ -553,7 +554,7 @@ uint8_t MCU_Read(mcu_t& mcu, uint32_t address)
                 }
                 else
                 {
-                    //fprintf(stderr, "Unknown read %x\n", address);
+                    Diag_Printf(Diag_Category::Debug, "Unknown read %x\n", address);
                     ret = 0xff;
                 }
                 //
@@ -676,8 +677,8 @@ void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value)
                     }
                     else if (address == (base | 0x402u))
                         mcu.ga_int_enable = (uint8_t)(value << 1);
-                    //else
-                    //    fprintf(stderr, "Unknown write %x %x\n", address, value);
+                    else
+                        Diag_Printf(Diag_Category::Debug, "Unknown write %x %x\n", address, value);
                     //
                     // e400: always 4?
                     // e401: SC0-6?
@@ -712,7 +713,7 @@ void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value)
                 }
                 else
                 {
-                    //fprintf(stderr, "Unknown write %x %x\n", address, value);
+                    Diag_Printf(Diag_Category::Debug, "Unknown write %x %x\n", address, value);
                 }
             }
             else
@@ -755,7 +756,7 @@ void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value)
                 }
                 else
                 {
-                    //fprintf(stderr, "Unknown write %x %x\n", address, value);
+                    Diag_Printf(Diag_Category::Debug, "Unknown write %x %x\n", address, value);
                 }
             }
         }
@@ -765,7 +766,7 @@ void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value)
         }
         else
         {
-            //fprintf(stderr, "Unknown write %x %x\n", address, value);
+            Diag_Printf(Diag_Category::Debug, "Unknown write %x %x\n", address, value);
         }
     }
     else if (page == 5 && mcu.is_mk1)
@@ -786,7 +787,7 @@ void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value)
     }
     else
     {
-        //fprintf(stderr, "Unknown write %x %x\n", (uint32_t)(page << 16) | address, value);
+        Diag_Printf(Diag_Category::Debug, "Unknown write %x %x\n", (uint32_t)(page << 16) | address, value);
     }
 }
 

--- a/src/nuked-sc55/backend/pcm.cpp
+++ b/src/nuked-sc55/backend/pcm.cpp
@@ -31,7 +31,6 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include "pcm.h"
 #include "mcu.h"
 #include "mcu_interrupt.h"
@@ -68,7 +67,6 @@ uint8_t PCM_ReadROM(pcm_t& pcm, uint32_t address)
         case 6:
             if (pcm.mcu->is_jv880)
                 return pcm.waverom_exp[(address & 0x1fffff) + (uint32_t)((bank - 3) * 0x200000)];
-            [[fallthrough]];
         default:
             break;
     }
@@ -330,6 +328,7 @@ inline void calc_tv(pcm_t& pcm, int e, int adjust, uint16_t *levelcur, int activ
     int speed = adjust & 0xff;
     int target = (adjust >> 8) & 0xff;
 
+                
     const bool w1 = (speed & 0xf0) == 0;
     const bool w2 = w1 || (speed & 0x10) != 0;
     const bool w3 = pcm.nfs &&
@@ -340,6 +339,7 @@ inline void calc_tv(pcm_t& pcm, int e, int adjust, uint16_t *levelcur, int activ
         type |= 2;
     if ((speed & 0x80) == 0 || (speed & 0x40) == 0)
         type |= 4;
+
 
     bool write = !active;
     int addlow = 0;
@@ -604,6 +604,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
 
             pcm.ram1[30][0] = (uint32_t)(pcm.accum_l & pcm.config.write_mask);
             pcm.ram1[30][1] = (uint32_t)(pcm.accum_r & pcm.config.write_mask);
+            
 
             int32_t samp_l = (int32_t)((pcm.ram1[30][2] & (uint32_t)(~pcm.config.write_mask)) << 12);
             int32_t samp_r = (int32_t)((pcm.ram1[30][4] & (uint32_t)(~pcm.config.write_mask)) << 12);
@@ -629,6 +630,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 pcm.ram1[30][0] = (uint32_t)(pcm.accum_l & pcm.config.write_mask);
                 pcm.ram1[30][1] = (uint32_t)(pcm.accum_r & pcm.config.write_mask);
 
+
                 samp_l = (int32_t)((pcm.ram1[30][3] & (uint32_t)(~pcm.config.write_mask)) << 12);
                 samp_r = (int32_t)((pcm.ram1[30][5] & (uint32_t)(~pcm.config.write_mask)) << 12);
 
@@ -646,6 +648,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
         }
 
         // chorus/reverb
+
         { // fixme
             if (pcm.ram2[31][8] & 0x8000)
                 pcm.ram2[31][9] = pcm.ram2[31][8] & 0x7fff;
@@ -657,6 +660,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             else
                 pcm.ram2[31][9] = (0x4000 - pcm.ram2[31][8]) & 0x7fff;
         }
+
         {
             int v1 = pcm.ram2[31][1];
 
@@ -665,6 +669,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
 
             pcm.ram1[29][1] = (uint32_t)addclip20(m1 >> 1, m2 >> 1, (m1 | m2) & 1); // 16
         }
+
         {
             const bool okey = (pcm.ram2[31][7] & 0x20) != 0;
             const bool key = 1;
@@ -672,6 +677,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             int u = 0;
             calc_tv(pcm, 1, pcm.ram2[30][0], &pcm.ram2[30][9], active, &u);
         }
+
         {
             int v1 = pcm.ram2[30][1];
             int m1 = multi((int32_t)pcm.ram1[29][0], (int8_t)(v1 >> 8)) >> 5; // 17
@@ -730,6 +736,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 int m2 = multi(v3, (int8_t)(v1 & 255)) >> 5;
                 pcm.ram1[28][1] = (uint32_t)addclip20(m2 >> 1, s2, m2 & 1);
 
+
                 pcm.ram1[28][2] = (uint32_t)eram_unpack(pcm, pcm.ram2[28][5] + pcm.tv_counter);
             }
             {
@@ -747,10 +754,12 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 int m2 = multi(v3, (int8_t)(v1 & 255)) >> 5;
                 pcm.ram1[28][3] = (uint32_t)addclip20(m2 >> 1, s2, m2 & 1);
 
+
                 pcm.ram1[28][4] = (uint32_t)eram_unpack(pcm, pcm.ram2[29][1] + pcm.tv_counter);
             }
             {
                 // 5
+
                 int v1 = pcm.ram2[30][7];
                 int m1 = multi((int32_t)pcm.ram1[29][2], (int8_t)(v1 >> 8)) >> 5;
                 int s1 = eram_unpack(pcm, pcm.ram2[29][0] + pcm.tv_counter);
@@ -761,6 +770,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 6
+
                 int v1 = pcm.ram2[30][8];
                 int m1 = multi((int32_t)pcm.ram1[29][3], (int8_t)(v1 >> 8)) >> 5;
                 int s1 = eram_unpack(pcm, pcm.ram2[29][8] + pcm.tv_counter);
@@ -773,6 +783,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 7
+
                 int v1 = pcm.ram2[30][9];
                 int v2 = (int)pcm.ram1[28][3];
                 int m1 = multi((int32_t)pcm.ram1[29][2], (int8_t)(v1 >> 8)) >> 5;
@@ -784,6 +795,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 8
+
                 int v1 = pcm.ram2[30][6];
                 int m1 = multi((int32_t)pcm.ram1[28][2], (int8_t)(v1 >> 8)) >> 5;
 
@@ -792,10 +804,12 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 int m2 = multi(v2, (int8_t)(v1 & 255)) >> 5;
                 pcm.ram1[28][2] = (uint32_t)addclip20((int32_t)pcm.ram1[28][2], m2 >> 1, m2 & 1);
 
+
                 pcm.ram1[28][1] = (uint32_t)eram_unpack(pcm, pcm.ram2[28][9] + pcm.tv_counter);
             }
             {
                 // 9
+
                 int v1 = pcm.ram2[30][6];
                 int m1 = multi((int32_t)pcm.ram1[28][4], (int8_t)(v1 >> 8)) >> 5;
 
@@ -804,10 +818,12 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 int m2 = multi(v2, (int8_t)(v1 & 255)) >> 5;
                 pcm.ram1[28][4] = (uint32_t)addclip20((int32_t)pcm.ram1[28][4], m2 >> 1, m2 & 1);
 
+
                 pcm.ram1[29][4] = (uint32_t)eram_unpack(pcm, pcm.ram2[29][5] + pcm.tv_counter);
             }
             {
                 // 10
+
                 int v1 = pcm.ram2[30][6];
                 int v2 = (int)pcm.ram1[28][1];
                 int m1 = multi(v2, (int8_t)(v1 >> 8)) >> 5;
@@ -821,6 +837,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 11
+
                 int v1 = pcm.ram2[30][6];
                 int v2 = (int)pcm.ram1[29][4];
                 int m1 = multi(v2, (int8_t)(v1 >> 8)) >> 5;
@@ -830,23 +847,29 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 int m2 = multi(v3, (int8_t)(v1 & 255)) >> 5;
                 pcm.ram1[28][0] = (uint32_t)addclip20(m2 >> 1, v2, m2 & 1);
 
+
                 eram_pack(pcm, pcm.ram2[28][5] + pcm.tv_counter, pcm.ram1[28][2]);
 
                 eram_pack(pcm, pcm.ram2[29][0] + pcm.tv_counter, pcm.ram1[28][5]);
             }
             {
                 // 12
+
                 pcm.ram1[28][5] = (uint32_t)eram_unpack(pcm, pcm.ram2[28][6] + pcm.tv_counter);
             }
+
             {
                 // 13
+
                 int s1 = eram_unpack(pcm, pcm.ram2[28][10] + pcm.tv_counter);
                 pcm.ram1[28][5] = (uint32_t)addclip20((int32_t)pcm.ram1[28][5], s1, 0);
 
                 pcm.ram1[28][2] = (uint32_t)eram_unpack(pcm, pcm.ram2[29][2] + pcm.tv_counter);
             }
+
             {
                 // 14
+
                 int s1 = eram_unpack(pcm, pcm.ram2[29][6] + pcm.tv_counter);
                 int t1 = addclip20(s1, (int32_t)pcm.ram1[28][2], 0); // 6
 
@@ -854,23 +877,29 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
 
                 pcm.ram1[28][2] = (uint32_t)eram_unpack(pcm, pcm.ram2[28][7] + pcm.tv_counter);
             }
+
             {
                 // 15
+
                 int s1 = eram_unpack(pcm, pcm.ram2[28][11] + pcm.tv_counter);
                 pcm.ram1[28][2] = (uint32_t)addclip20((int32_t)pcm.ram1[28][2], s1, 0);
 
                 pcm.ram1[28][3] = (uint32_t)eram_unpack(pcm, pcm.ram2[29][3] + pcm.tv_counter);
             }
+
             {
                 // 16
+
                 int s1 = eram_unpack(pcm, pcm.ram2[29][7] + pcm.tv_counter);
                 int t1 = addclip20(s1, (int32_t)pcm.ram1[28][2], 0);
                 pcm.ram1[28][2] = (uint32_t)addclip20(t1, (int32_t)pcm.ram1[28][3], 0);
+
 
                 eram_pack(pcm, pcm.ram2[29][1] + pcm.tv_counter, pcm.ram1[28][4]);
 
                 eram_pack(pcm, pcm.ram2[28][8] + pcm.tv_counter, pcm.ram1[28][1]);
             }
+
             {
                 // 17
                 int v1 = pcm.ram2[30][2];
@@ -886,6 +915,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 eram_pack(pcm, pcm.ram2[28][9] + pcm.tv_counter, pcm.ram1[29][5]);
                 pcm.ram1[29][5] = (uint32_t)t1;
             }
+
             {
                 // 18
                 int v1 = pcm.ram2[30][3];
@@ -901,6 +931,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 19
+
                 int v1 = pcm.ram2[31][9];
 
                 int s1 = eram_unpack(pcm, pcm.ram2[29][10] + pcm.tv_counter); //? 3a6d
@@ -916,6 +947,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 20
+
                 int v1 = pcm.ram2[31][10];
 
                 int s1 = eram_unpack(pcm, pcm.ram2[29][11] + pcm.tv_counter); //? 3a1d
@@ -933,6 +965,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 21
+
                 int v1 = pcm.ram2[31][2];
                 int v2 = (int)pcm.ram1[29][5];
 
@@ -944,6 +977,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 22
+
                 int v1 = pcm.ram2[31][3];
                 int v2 = (int)pcm.ram1[29][5];
 
@@ -955,6 +989,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 23
+
                 int v1 = pcm.ram2[31][4];
                 int v2 = (int)pcm.ram1[28][1];
 
@@ -966,6 +1001,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
             {
                 // 31
+
                 int v1 = pcm.ram2[31][5];
                 int v2 = (int)pcm.ram1[28][1];
 
@@ -977,6 +1013,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
 
                 {
                     // address generator
+
                     const bool key = 1;
                     const bool okey = (pcm.ram2[31][7] & 0x20) != 0;
                     const bool active = key && okey;
@@ -1002,6 +1039,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                         pcm.ram2[31][8] &= ~0x3fff;
                         pcm.ram2[31][8] |= sub_phase & 0x3fff;
                     }
+
 
                     // address 0
                     int address_cnt = address;
@@ -1072,6 +1110,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             const bool kon = key && !okey;
 
             // address generator
+
             bool b15 = (ram2[8] & 0x8000) != 0; // 0
             const bool b6 = (ram2[7] & 0x40) != 0; // 1
             const bool b7 = (ram2[7] & 0x80) != 0; // 1
@@ -1124,6 +1163,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 ram2[8] &= ~0x3fff;
                 ram2[8] |= sub_phase & 0x3fff;
             }
+
 
             // address 0
             int address_cnt = address;
@@ -1261,6 +1301,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
             }
 
             // dpcm
+
             // 18
             int reference = (int)ram1[5];
 
@@ -1302,6 +1343,7 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
                 reference = addclip20(reference, shifted >> 1, shifted & 1);
 
             // interpolation
+
             int test = (int)ram1[5];
 
             int step0 = multi(interp_lut[0][interp_ratio] << 6, (int8_t)samp0) >> 8;
@@ -1428,12 +1470,13 @@ void PCM_Update(pcm_t& pcm, uint64_t cycles)
 
             int rc0 = multi(sample3, (int8_t)((rc >> 8) & 255)) >> 5; // reverb
             int rc1 = multi(sample3, (int8_t)((rc >> 0) & 255)) >> 5; // chorus
-
+            
             // mix reverb/chorus?
             int slot2 = (slot == pcm.config.reg_slots - 1) ? 31 : slot + 1;
             switch (slot2)
             {
                 // 17, 18 - reverb
+
                 case 17:
                     pcm.ram1[31][1] = (uint32_t)addclip20((int32_t)pcm.ram1[31][1], rcadd[0] >> 1, rcadd[0] & 1);
                     break;

--- a/src/nuked-sc55/backend/rom.cpp
+++ b/src/nuked-sc55/backend/rom.cpp
@@ -1,5 +1,7 @@
 #include "rom.h"
 
+#include "standard_romsets.h"
+
 const char* rs_name[ROMSET_COUNT] = {
     "SC-55mk2",
     "SC-55st",
@@ -24,9 +26,36 @@ const char* rs_name_simple[ROMSET_COUNT] = {
     "sc155mk2"
 };
 
+// This is a matrix where each row is a romset, and each column is a RomLocation
+constexpr RomLocationSet REQUIRED_ROMS[ROMSET_COUNT] = {
+    // MK2
+    {true, true, true, true, true, false, false, false},
+    // ST
+    {true, true, true, true, true, false, false, false},
+    // MK1
+    {true, true, false, true, true, true, false, false},
+    // CM300
+    {true, true, false, true, true, true, false, false},
+    // JV880
+    {true, true, false, true, true, false, false, false},
+    // SCB55
+    {true, true, false, true, false, true, false, false},
+    // RLP3237
+    {true, true, false, true, false, false, false, false},
+    // SC155
+    {true, true, false, true, true, true, false, false},
+    // SC155MK2
+    {true, true, true, true, true, false, false, false},
+};
+
 const char* RomsetName(Romset romset)
 {
     return rs_name[(size_t)romset];
+}
+
+const char* ParsableRomsetName(Romset romset)
+{
+    return rs_name_simple[(size_t)romset];
 }
 
 bool ParseRomsetName(std::string_view name, Romset& romset)
@@ -90,4 +119,86 @@ bool IsOptionalRom(Romset romset, RomLocation location)
 {
     return romset == Romset::JV880 &&
            (location == RomLocation::WAVEROM_CARD || location == RomLocation::WAVEROM_EXP);
+}
+
+bool IsRequiredRom(Romset romset, RomLocation location)
+{
+    return REQUIRED_ROMS[(size_t)romset][(size_t)location];
+}
+
+const RomsetDefinition* RomsetRegistry::GetDefinition(std::string_view name) const
+{
+    const auto it = m_name_map.find(name);
+
+    if (it == m_name_map.end())
+    {
+        return nullptr;
+    }
+
+    return &m_romsets[it->second];
+}
+
+bool RomsetRegistry::AddRomset(const RomsetDefinition& romset)
+{
+    const size_t index  = m_romsets.size();
+    auto [it, inserted] = m_name_map.insert(std::make_pair(romset.name, index));
+    if (inserted)
+    {
+        m_romsets.push_back(romset);
+    }
+    return inserted;
+}
+
+void RomsetRegistry::GetAllRomsetNames(StringVector& out_names) const
+{
+    out_names.clear();
+    for (const auto& romset : m_romsets)
+    {
+        out_names.emplace_back(romset.name);
+    }
+}
+
+// Returns all the names under a specific romset family.
+void RomsetRegistry::GetNamesForFamily(Romset romset, StringVector& out_names) const
+{
+    out_names.clear();
+    for (const auto& def : m_romsets)
+    {
+        if (def.romset == romset)
+        {
+            out_names.emplace_back(def.name);
+        }
+    }
+}
+
+bool RomsetRegistry::ContainsRomset(std::string_view name) const
+{
+    return m_name_map.contains(name);
+}
+
+bool RomsetRegistry::GetRomsetFamily(std::string_view name, Romset& out_family) const
+{
+    const auto it = m_name_map.find(name);
+
+    if (it == m_name_map.end())
+    {
+        return false;
+    }
+
+    const size_t index = it->second;
+
+    out_family = m_romsets[index].romset;
+    return true;
+}
+
+RomsetRegistry RomsetRegistry::CreateWithDefaultHashes()
+{
+    RomsetRegistry registry;
+
+    for (auto& def : GetStandardRomsetDefinitions())
+    {
+        registry.AddRomset(def);
+    }
+
+    return registry;
 }

--- a/src/nuked-sc55/backend/rom.h
+++ b/src/nuked-sc55/backend/rom.h
@@ -4,7 +4,14 @@
 #include <span>
 #include <string_view>
 
-enum class Romset {
+#include "sha256.h"
+#include "string_map.h"
+#include "string_vector.h"
+
+// A Romset represents a family of roms. Each Romset may have multiple valid sets of roms. This is the case when a
+// Romset has multiple versions.
+enum class Romset
+{
     MK2,
     ST,
     MK1,
@@ -18,13 +25,19 @@ enum class Romset {
 
 constexpr size_t ROMSET_COUNT = 9;
 
+// Returns a formatted romset name suitable for displaying to users.
 const char* RomsetName(Romset romset);
+
+// Returns a parsable romset name. Parsable romset names are also the canonical
+// representation for a romset family.
+const char* ParsableRomsetName(Romset romset);
 
 bool ParseRomsetName(std::string_view name, Romset& romset);
 
 std::span<const char*> GetParsableRomsetNames();
 
-// Symbolic name for the various roms used by the emulator.
+// Symbolic name for the various roms used by the emulator. A Romset consists of several roms each at a distinct
+// RomLocation. A Romset does not require all RomLocations to be populated.
 enum class RomLocation
 {
     // MCU roms
@@ -49,7 +62,225 @@ const char* ToCString(RomLocation location);
 // Set of rom locations. Indexed by RomLocation.
 using RomLocationSet = std::array<bool, ROMLOCATION_COUNT>;
 
+constexpr RomLocationSet ROMLOCATION_ALL{true, true, true, true, true, true, true, true};
+
 // Returns true if `location` represents a waverom location.
 bool IsWaverom(RomLocation location);
 
 bool IsOptionalRom(Romset romset, RomLocation location);
+bool IsRequiredRom(Romset romset, RomLocation location);
+
+// Helper type for constructing RomsetDefinitions at compile time. An array of
+// `RomHashLocationPair` has a dense representation, but can be converted to
+// the sparse representation required by `RomsetHashes` at compile time. This
+// is provided for convenience because writing arrays with holes is
+// error-prone.
+struct RomHashLocationPair
+{
+    SHA256_Digest hash;
+    RomLocation   location;
+};
+
+// This is a sparse array containing SHA256 hashes for each possible rom in a
+// romset. Most romsets will only use 5 slots in the array, so it is necessary
+// to check that a rom is present before attempting to use the hash for a rom
+// location. This can be done manually or by using `GetValidLocations` to skip
+// holes in the array.
+class RomsetHashes
+{
+public:
+    constexpr RomsetHashes() = default;
+
+    // Expands a `RomHashLocationPair` list into a `RomsetHashes`.
+    constexpr RomsetHashes(std::initializer_list<RomHashLocationPair> pairs)
+    {
+        for (const RomHashLocationPair& pair : pairs)
+        {
+            m_hashes[(size_t)pair.location] = pair.hash;
+        }
+    }
+
+    constexpr const SHA256_Digest& operator[](RomLocation index) const
+    {
+        return m_hashes[(size_t)index];
+    }
+
+    constexpr SHA256_Digest& operator[](RomLocation index)
+    {
+        return m_hashes[(size_t)index];
+    }
+
+    constexpr bool ContainsHash(RomLocation rom) const
+    {
+        return (*this)[rom] != SHA256_Digest{};
+    }
+
+    class LocationRange;
+
+    class LocationIterator
+    {
+    public:
+        constexpr LocationIterator& operator++()
+        {
+            m_raw_location = m_parent.FindNextLocation(m_raw_location + 1);
+            return *this;
+        }
+
+        constexpr bool operator==(const LocationIterator& rhs)
+        {
+            return &m_parent == &rhs.m_parent && m_raw_location == rhs.m_raw_location;
+        }
+
+        constexpr bool operator!=(const LocationIterator& rhs)
+        {
+            return !(*this == rhs);
+        }
+
+        constexpr RomLocation operator*() const
+        {
+            return (RomLocation)m_raw_location;
+        }
+
+    private:
+        friend class LocationRange;
+
+        constexpr LocationIterator(const RomsetHashes& parent)
+            : m_parent(parent),
+              m_raw_location(ROMLOCATION_COUNT)
+        {
+        }
+
+        constexpr LocationIterator(const RomsetHashes& parent, size_t pos)
+            : m_parent(parent),
+              m_raw_location(pos)
+        {
+        }
+
+        const RomsetHashes& m_parent;
+        size_t              m_raw_location;
+    };
+
+    class LocationRange
+    {
+    public:
+        constexpr LocationIterator begin() const
+        {
+            return m_first;
+        }
+
+        constexpr LocationIterator end() const
+        {
+            return m_last;
+        }
+
+    private:
+        friend class RomsetHashes;
+
+        constexpr LocationRange(const RomsetHashes& parent)
+            : m_first(parent, parent.FindNextLocation(0)),
+              m_last(parent)
+        {
+        }
+
+        LocationIterator m_first, m_last;
+    };
+
+    constexpr LocationRange GetValidLocations() const
+    {
+        return LocationRange(*this);
+    }
+
+private:
+    constexpr size_t FindNextLocation(size_t start) const
+    {
+        for (size_t i = start; i < ROMLOCATION_COUNT; ++i)
+        {
+            if (ContainsHash((RomLocation)i))
+            {
+                return i;
+            }
+        }
+        return ROMLOCATION_COUNT;
+    }
+
+    std::array<SHA256_Digest, ROMLOCATION_COUNT> m_hashes{};
+};
+
+// Contains a complete description of a romset.
+struct RomsetDefinition
+{
+    const char*  name;
+    Romset       romset;
+    RomsetHashes hashes;
+
+    constexpr const SHA256_Digest& GetHash(RomLocation rom) const
+    {
+        return hashes[rom];
+    }
+
+    constexpr bool ContainsHash(RomLocation rom) const
+    {
+        return hashes.ContainsHash(rom);
+    }
+
+    constexpr void ReplaceHash(RomLocation rom, const SHA256_Digest& hash)
+    {
+        hashes[rom] = hash;
+    }
+
+    // Returns a range that iterates over only the RomLocations used by this set.
+    constexpr RomsetHashes::LocationRange GetValidLocations() const
+    {
+        return hashes.GetValidLocations();
+    }
+};
+
+// Contains metadata for romsets. Romsets are registered with instances of this type by name (e.g. "mk1-v1.00") along
+// with the hashes of any roms in that romset. After registration, this type can be used to efficiently query which of
+// those romsets exist on disk.
+class RomsetRegistry
+{
+public:
+    // Constructs an empty registry.
+    RomsetRegistry() = default;
+
+    // Returns the definition for `name` if it exists or `nullptr` otherwise.
+    // The returned pointer is invalidated if the registry is modified.
+    const RomsetDefinition* GetDefinition(std::string_view name) const;
+
+    // Adds `romset` to the registry. Returns true if successful and false if
+    // the registry already contains a definition with the same name.
+    bool AddRomset(const RomsetDefinition& romset);
+
+    // Returns all of the names registered with the registry. `out_names` will be cleared before receiving the names.
+    void GetAllRomsetNames(StringVector& out_names) const;
+
+    // Returns all of the names under a specific romset family. `out_names` will be cleared before receiving the names.
+    void GetNamesForFamily(Romset romset, StringVector& out_names) const;
+
+    // Returns true if there is metadata associated with `name`. Note that this does NOT return whether or not the file
+    // was located on disk. For that functionality, use `ContainsRomsetFiles`.
+    bool ContainsRomset(std::string_view name) const;
+
+    // Returns true if the romset given by `name` exists and `out_family` receives the romset family.
+    bool GetRomsetFamily(std::string_view name, Romset& out_family) const;
+
+    // Iterators over the contained definitions. Iterators are invalidated if the registry is modified.
+    const RomsetDefinition* begin() const
+    {
+        return m_romsets.data();
+    }
+
+    const RomsetDefinition* end() const
+    {
+        return m_romsets.data() + m_romsets.size();
+    }
+
+    // Creates a registry containing standard, supported romsets.
+    static RomsetRegistry CreateWithDefaultHashes();
+
+private:
+    std::vector<RomsetDefinition> m_romsets;
+    // Maps romset identifiers to index in `m_romsets`
+    StringMap<size_t> m_name_map;
+};

--- a/src/nuked-sc55/backend/rom_io.cpp
+++ b/src/nuked-sc55/backend/rom_io.cpp
@@ -1,13 +1,10 @@
 #include "rom_io.h"
-#include "cast.h"
-#include <fstream>
 
-extern "C"
-{
-#include "sha/sha.h"
-}
+#include <filesystem>
+#include <utility>
 
-using SHA256Digest = std::array<uint8_t, SHA256HashSize>;
+#include "file_hashing.h"
+#include "file_io.h"
 
 const char* legacy_rom_names[(size_t)ROMSET_COUNT][ROMLOCATION_COUNT] = {
     // MK2
@@ -210,497 +207,56 @@ void unscramble(const uint8_t *src, uint8_t *dst, int len)
     }
 }
 
-bool ReadAllBytes(const std::filesystem::path& filename, std::vector<uint8_t>& buffer)
+bool IsCompleteRomset(const RomsetInfo& info, Romset romset, RomCompletionStatusSet* status)
 {
-    std::ifstream input(filename, std::ios::binary);
-
-    if (!input)
-    {
-        return false;
-    }
-
-    input.seekg(0, std::ios::end);
-    std::streamoff byte_count = input.tellg();
-    input.seekg(0, std::ios::beg);
-
-    buffer.resize(RangeCast<size_t>(byte_count));
-
-    input.read((char*)buffer.data(), RangeCast<std::streamsize>(byte_count));
-
-    return input.good();
-}
-
-constexpr uint8_t HexValue(char x)
-{
-    if (x >= '0' && x <= '9')
-    {
-        return (uint8_t)(x - '0');
-    }
-    else if (x >= 'a' && x <= 'f')
-    {
-        return 10 + (uint8_t)(x - 'a');
-    }
-    else
-    {
-        throw "character out of range";
-    }
-}
-
-// Compile time string-to-SHA256Digest
-template <size_t N>
-constexpr SHA256Digest ToDigest(const char (&s)[N])
-{
-    static_assert(N == 65); // 64 + null terminator
-
-    SHA256Digest hash;
-    for (size_t i = 0; i < N / 2; ++i)
-    {
-        hash[i] = (uint8_t)((HexValue(s[2 * i + 0]) << 4) | HexValue(s[2 * i + 1]));
-    }
-
-    return hash;
-}
-
-struct KnownHash
-{
-    SHA256Digest hash;
-    Romset       romset;
-    RomLocation  location;
-};
-
-// clang-format off
-static constexpr KnownHash ROM_HASHES[] = {
-    ///////////////////////////////////////////////////////////////////////////
-    // SC-55mk2 (v1.00)
-    ///////////////////////////////////////////////////////////////////////////
-    
-    // TODO: missing hashes for this ROM set
-
-    // R15199848 (H8/532 mcu)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::MK2, RomLocation::ROM1},
-    // R15199859 (H8/532 extra code)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::MK2, RomLocation::ROM2},
-    // R15209463 (M37450M2 mcu)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::MK2, RomLocation::SMROM},
-    // R15209359 (WAVE 16M)
-    {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), Romset::MK2, RomLocation::WAVEROM1},
-    // R15279813 (WAVE 8M)
-    {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), Romset::MK2, RomLocation::WAVEROM2},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // SC-55mk2/SC-155mk2 (v1.01)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199858 (H8/532 mcu)
-    {ToDigest("8a1eb33c7599b746c0c50283e4349a1bb1773b5c0ec0e9661219bf6c067d2042"), Romset::MK2, RomLocation::ROM1},
-    // R00233567 (H8/532 extra code)
-    {ToDigest("a4c9fd821059054c7e7681d61f49ce6f42ed2fe407a7ec1ba0dfdc9722582ce0"), Romset::MK2, RomLocation::ROM2},
-    // R15199880 (M37450M2 mcu)
-    {ToDigest("b0b5f865a403f7308b4be8d0ed3ba2ed1c22db881b8a8326769dea222f6431d8"), Romset::MK2, RomLocation::SMROM},
-    // R15209359 (WAVE 16M)
-    {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), Romset::MK2, RomLocation::WAVEROM1},
-    // R15279813 (WAVE 8M)
-    {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), Romset::MK2, RomLocation::WAVEROM2},
-
-    // R15199858 (H8/532 mcu)
-    {ToDigest("8a1eb33c7599b746c0c50283e4349a1bb1773b5c0ec0e9661219bf6c067d2042"), Romset::SC155MK2, RomLocation::ROM1},
-    // R00233567 (H8/532 extra code)
-    {ToDigest("a4c9fd821059054c7e7681d61f49ce6f42ed2fe407a7ec1ba0dfdc9722582ce0"), Romset::SC155MK2, RomLocation::ROM2},
-    // R15199880 (M37450M2 mcu)
-    {ToDigest("b0b5f865a403f7308b4be8d0ed3ba2ed1c22db881b8a8326769dea222f6431d8"), Romset::SC155MK2, RomLocation::SMROM},
-    // R15209359 (WAVE 16M)
-    {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), Romset::SC155MK2, RomLocation::WAVEROM1},
-    // R15279813 (WAVE 8M)
-    {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), Romset::SC155MK2, RomLocation::WAVEROM2},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // SC-55st (v1.01)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199858 (H8/532 mcu)
-    {ToDigest("8a1eb33c7599b746c0c50283e4349a1bb1773b5c0ec0e9661219bf6c067d2042"), Romset::ST, RomLocation::ROM1},
-    // R00561413 (H8/532 extra code)
-    {ToDigest("03517ac0a3b1ad8b69a1a4ee045e0c21da0170027bd1ba1bd3cf72cd017bbe6a"), Romset::ST, RomLocation::ROM2},
-    // R15199880 (M37450M2 mcu)
-    {ToDigest("b0b5f865a403f7308b4be8d0ed3ba2ed1c22db881b8a8326769dea222f6431d8"), Romset::ST, RomLocation::SMROM},
-    // R15209359 (WAVE 16M)
-    {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), Romset::ST, RomLocation::WAVEROM1},
-    // R15279813 (WAVE 8M)
-    {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), Romset::ST, RomLocation::WAVEROM2},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // SC-55 (v1.00)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199748 (H8/532 mcu)
-    {ToDigest("b4ecf44bc0520322b0d114d397951d3bf92ca6fa51d0d27b2407df58a6be2efe"), Romset::MK1, RomLocation::ROM1},
-    // R15449258 (H8/532 extra code)
-    {ToDigest("014e2e21ea30de7a1e4f1cdea14dd9a719960535e257a9e40e98dbb1a5870226"), Romset::MK1, RomLocation::ROM2},
-    // R15209276 (WAVE A)
-    {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), Romset::MK1, RomLocation::WAVEROM1},
-    // R15209277 (WAVE B)
-    {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), Romset::MK1, RomLocation::WAVEROM2},
-    // R15209281 (WAVE C)
-    {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), Romset::MK1, RomLocation::WAVEROM3},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // SC-55 (v1.10)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199736 (H8/532 mcu)
-    {ToDigest("2fe88ec39f3ef4b1de8cdf74527419467975c47f7aacfcd07605e01d54bd89b5"), Romset::MK1, RomLocation::ROM1},
-    // R15209275 (H8/532 extra code)
-    {ToDigest("ec064d6c4fc70ec990911089d966043cb819fba0e26e6f6afdd0a05e5301b91b"), Romset::MK1, RomLocation::ROM2},
-    // R15209276 (WAVE A)
-    {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), Romset::MK1, RomLocation::WAVEROM1},
-    // R15209277 (WAVE B)
-    {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), Romset::MK1, RomLocation::WAVEROM2},
-    // R15209281 (WAVE C)
-    {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), Romset::MK1, RomLocation::WAVEROM3},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // SC-55 (v1.20)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199778 (H8/532 mcu)
-    {ToDigest("7e1bacd1d7c62ed66e465ba05597dcd60dfc13fc23de0287fdbce6cf906c6544"), Romset::MK1, RomLocation::ROM1},
-    // R15209337 (H8/532 extra code)
-    {ToDigest("22ce6ca59e6332143b335525e81fab501ea6fccce4b7e2f3bfc2cc8bf6612ff6"), Romset::MK1, RomLocation::ROM2},
-    // R15209276 (WAVE A)
-    {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), Romset::MK1, RomLocation::WAVEROM1},
-    // R15209277 (WAVE B)
-    {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), Romset::MK1, RomLocation::WAVEROM2},
-    // R15209281 (WAVE C)
-    {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), Romset::MK1, RomLocation::WAVEROM3},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // SC-55 (v1.21)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199778 (H8/532 mcu)
-    {ToDigest("7e1bacd1d7c62ed66e465ba05597dcd60dfc13fc23de0287fdbce6cf906c6544"), Romset::MK1, RomLocation::ROM1},
-    // R15209363 (H8/532 extra code)
-    {ToDigest("effc6132d68f7e300aaef915ccdd08aba93606c22d23e580daf9ea6617913af1"), Romset::MK1, RomLocation::ROM2},
-    // R15209276 (WAVE A)
-    {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), Romset::MK1, RomLocation::WAVEROM1},
-    // R15209277 (WAVE B)
-    {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), Romset::MK1, RomLocation::WAVEROM2},
-    // R15209281 (WAVE C)
-    {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), Romset::MK1, RomLocation::WAVEROM3},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // SC-55 (v2.00)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199799 (H8/532 mcu)
-    {ToDigest("24a65c97cdbaa847d6f59193523ce63c73394b4b693a6517ee79441f2fb8a3ee"), Romset::MK1, RomLocation::ROM1},
-    // R15209387 (H8/532 extra code)
-    {ToDigest("f5dac35d450ab986570a209dff3816eec75cee669e161f54b51224b467dd0bcc"), Romset::MK1, RomLocation::ROM2},
-    // R15209276 (WAVE A)
-    {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), Romset::MK1, RomLocation::WAVEROM1},
-    // R15209277 (WAVE B)
-    {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), Romset::MK1, RomLocation::WAVEROM2},
-    // R15209281 (WAVE C)
-    {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), Romset::MK1, RomLocation::WAVEROM3},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // CM-300/SCC-1 (v1.10)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199774 (H8/532 mcu)
-    {ToDigest("72ed35481efbf25b3c492b83183655d17a3b266ecb30ffbc6dc977e6a8d261b2"), Romset::CM300, RomLocation::ROM1},
-    // R15279809 (H8/532 extra code)
-    {ToDigest("0283d32e6993a0265710c4206463deb937b0c3a4819b69f471a0eca5865719f9"), Romset::CM300, RomLocation::ROM2},
-    // R15279806 (WAVE A)
-    {ToDigest("40c093cbfb4441a5c884e623f882a80b96b2527f9fd431e074398d206c0f073d"), Romset::CM300, RomLocation::WAVEROM1},
-    // R15279807 (WAVE B)
-    {ToDigest("9bbbcac747bd6f7a2693f4ef10633db8ab626f17d3d9c47c83c3839d4dd2f613"), Romset::CM300, RomLocation::WAVEROM2},
-    // R15279808 (WAVE C)
-    {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), Romset::CM300, RomLocation::WAVEROM3},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // CM-300/SCC-1 (v1.20)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199774 (H8/532 mcu)
-    {ToDigest("72ed35481efbf25b3c492b83183655d17a3b266ecb30ffbc6dc977e6a8d261b2"), Romset::CM300, RomLocation::ROM1},
-    // R15279812 (H8/532 extra code)
-    {ToDigest("fef1acb1969525d66238be5e7811108919b07a4df5fbab656ad084966373483f"), Romset::CM300, RomLocation::ROM2},
-    // R15279806 (WAVE A)
-    {ToDigest("40c093cbfb4441a5c884e623f882a80b96b2527f9fd431e074398d206c0f073d"), Romset::CM300, RomLocation::WAVEROM1},
-    // R15279807 (WAVE B)
-    {ToDigest("9bbbcac747bd6f7a2693f4ef10633db8ab626f17d3d9c47c83c3839d4dd2f613"), Romset::CM300, RomLocation::WAVEROM2},
-    // R15279808 (WAVE C)
-    {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), Romset::CM300, RomLocation::WAVEROM3},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // SCC-1A
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R00128523 (H8/532 mcu)
-    {ToDigest("9ec66abb5231b6c6f46f48b33d5412703041037d69a6803626ac402f25552af2"), Romset::CM300, RomLocation::ROM1},
-    // R00128567 (H8/532 extra code)
-    {ToDigest("f89442734fdebacae87c7707c01b2d7fdbf5940abae738987aee912d34b5882e"), Romset::CM300, RomLocation::ROM2},
-    // R15279806 (WAVE A)
-    {ToDigest("40c093cbfb4441a5c884e623f882a80b96b2527f9fd431e074398d206c0f073d"), Romset::CM300, RomLocation::WAVEROM1},
-    // R15279807 (WAVE B)
-    {ToDigest("9bbbcac747bd6f7a2693f4ef10633db8ab626f17d3d9c47c83c3839d4dd2f613"), Romset::CM300, RomLocation::WAVEROM2},
-    // R15279808 (WAVE C)
-    {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), Romset::CM300, RomLocation::WAVEROM3},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // JV-880 (v1.0.0 or v1.00)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // TODO: missing JV-880 optional ROMs
-
-    // R15199810 (H8/532 mcu)
-    {ToDigest("aabfcf883b29060198566440205f2fae1ce689043ea0fc7074842aaa4fd4823e"), Romset::JV880, RomLocation::ROM1},
-    // R15209386 (H8/532 extra code)
-    {ToDigest("11852e60ff597633c754c5441c1e3e06793bcd951fcea2c4969ac3041d130fce"), Romset::JV880, RomLocation::ROM2},
-    // R15209312 (WAVE A)
-    {ToDigest("aa3101a76d57992246efeda282a2cb0c0f8fdb441c2eed2aa0b0fad4d81f3ad4"), Romset::JV880, RomLocation::WAVEROM1},
-    // R15209313 (WAVE B)
-    {ToDigest("a7b50bb47734ee9117fa16df1f257990a9a1a0b5ed420337ae4310eb80df75c8"), Romset::JV880, RomLocation::WAVEROM2},
-    // R00000000 (PCM card)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::JV880, RomLocation::WAVEROM_CARD},
-    // R00000000 (Expansion PCB)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::JV880, RomLocation::WAVEROM_EXP},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // JV-880 (v1.0.1 or v1.01)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // TODO: missing JV-880 optional ROMs
-
-    // R15199810 (H8/532 mcu)
-    {ToDigest("aabfcf883b29060198566440205f2fae1ce689043ea0fc7074842aaa4fd4823e"), Romset::JV880, RomLocation::ROM1},
-    // R15209481 (H8/532 extra code)
-    {ToDigest("ed437f1bc75cc558f174707bcfeb45d5e03483efd9bfd0a382ca57c0edb2a40c"), Romset::JV880, RomLocation::ROM2},
-    // R15209312 (WAVE A)
-    {ToDigest("aa3101a76d57992246efeda282a2cb0c0f8fdb441c2eed2aa0b0fad4d81f3ad4"), Romset::JV880, RomLocation::WAVEROM1},
-    // R15209313 (WAVE B)
-    {ToDigest("a7b50bb47734ee9117fa16df1f257990a9a1a0b5ed420337ae4310eb80df75c8"), Romset::JV880, RomLocation::WAVEROM2},
-    // R00000000 (PCM card)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::JV880, RomLocation::WAVEROM_CARD},
-    // R00000000 (Expansion PCB)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::JV880, RomLocation::WAVEROM_EXP},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // SCB-55/RLP-3194
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199827 (H8/532 mcu)
-    {ToDigest("00df835d3f97fc8b0059db63f36d608eec2bfd1f51ad54eb5af52c868c1111b1"), Romset::SCB55, RomLocation::ROM1},
-    // R15279828 (H8/532 extra code)
-    {ToDigest("541be4d0b1ef0d07bb042ba67ffd099c8a5d746aac4cd24ce8842c034379f213"), Romset::SCB55, RomLocation::ROM2},
-    // R15209359 (WAVE 16M)
-    {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), Romset::SCB55, RomLocation::WAVEROM1},
-    // R15279813 (WAVE 8M)
-    {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), Romset::SCB55, RomLocation::WAVEROM3},
-    // ^NOTE: legacy loader looks for a file called wav "scb55_waverom2.bin", but during loading it is actually placed in WAVEROM3
-
-    ///////////////////////////////////////////////////////////////////////////
-    // RLP-3237
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199827 (H8/532 mcu)
-    {ToDigest("00df835d3f97fc8b0059db63f36d608eec2bfd1f51ad54eb5af52c868c1111b1"), Romset::RLP3237, RomLocation::ROM1},
-    // R15209486 (H8/532 extra code)
-    {ToDigest("e0a3d6d9b05e82374a0d289901273ce560ce1ead86459c75f844158b32d204a9"), Romset::RLP3237, RomLocation::ROM2},
-    // R15279824 (WAVE 16M)
-    {ToDigest("dae2a8bc0fd3bcaf3f5e3ab6c4c6fd30e2663bf26ca17afe52924874c0afc4e2"), Romset::RLP3237, RomLocation::WAVEROM1},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // SC-155 (rev 1)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // R15199799 (H8/532 mcu)
-    {ToDigest("24a65c97cdbaa847d6f59193523ce63c73394b4b693a6517ee79441f2fb8a3ee"), Romset::SC155, RomLocation::ROM1},
-    // R15209361 (H8/532 extra code)
-    {ToDigest("ceb7b9d3d9d264efe5dc3ba992b94f3be35eb6d0451abc574b6f6b5dc3db237b"), Romset::SC155, RomLocation::ROM2},
-    // R15209276 (WAVE A)
-    {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), Romset::SC155, RomLocation::WAVEROM1},
-    // R15209277 (WAVE B)
-    {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), Romset::SC155, RomLocation::WAVEROM2},
-    // R15209281 (WAVE C)
-    {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), Romset::SC155, RomLocation::WAVEROM3},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // SC-155 (rev 2)
-    ///////////////////////////////////////////////////////////////////////////
-
-    // TODO: missing hashes for this ROM set
-
-    // R15199799 (H8/532 mcu)
-    {ToDigest("24a65c97cdbaa847d6f59193523ce63c73394b4b693a6517ee79441f2fb8a3ee"), Romset::SC155, RomLocation::ROM1},
-    // R15209400 (H8/532 extra code)
-    {ToDigest("0000000000000000000000000000000000000000000000000000000000000000"), Romset::SC155, RomLocation::ROM2},
-    // R15209276 (WAVE A)
-    {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), Romset::SC155, RomLocation::WAVEROM1},
-    // R15209277 (WAVE B)
-    {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), Romset::SC155, RomLocation::WAVEROM2},
-    // R15209281 (WAVE C)
-    {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), Romset::SC155, RomLocation::WAVEROM3},
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Extra/modified ROMs
-    ///////////////////////////////////////////////////////////////////////////
-
-    // CTF patched ROMs from https://github.com/shingo45endo/sc55mk2-ctf-patcher
-
-    // Tone: Strict SC-55 | Drum: SC-55 v1.21 or earlier
-    {ToDigest("64f8c9daf1021cf86ea4ddf03a29b81b5ea0c18e74f462833023436388bb9dc4"), Romset::MK2, RomLocation::ROM2},
-    // Tone: Strict SC-55 | Drum: SC-55 v2.00
-    {ToDigest("14d14778caf46ffa9e3d608aa8e9c1a60c32bd4a536c26af3b2e1d81784c60f9"), Romset::MK2, RomLocation::ROM2},
-    // Tone: SC-55 | Drum: SC-55 v1.21 or earlier
-    {ToDigest("10b3f09485a74bb014f1a940d5c67f380c7979b62891d540d788154c83f17430"), Romset::MK2, RomLocation::ROM2},
-    // Tone: SC-55 | Drum: SC-55 v2.00
-    {ToDigest("a2c720be1ab9115930d27f821a413c0366b7bf0c4ddfe0dadc5086136a1a4345"), Romset::MK2, RomLocation::ROM2},
-    // Tone: SC-55mkII | Drum: SC-55 v1.21 or earlier
-    {ToDigest("16cec615da10089beffe6de5129ba8ba33fa1bf017a5e6b78ad1d6d15cf4708e"), Romset::MK2, RomLocation::ROM2},
-    // Tone: SC-55mkII | Drum: SC-55 v2.00
-    {ToDigest("c22bf7d34a3406530924d750b007bbdb470f3216c65086edb6e53023383ee907"), Romset::MK2, RomLocation::ROM2},
-};
-// clang-format on
-
-
-bool DetectRomsetsByHash(const std::filesystem::path& base_path,
-                             AllRomsetInfo&           all_info,
-                             RomLocationSet*          desired)
-{
-    std::error_code ec;
-
-    std::filesystem::directory_iterator dir_iter(base_path, ec);
-
-    if (ec)
-    {
-        //fprintf(stderr, "Failed to walk rom directory: %s\n", ec.message().c_str());
-        return false;
-    }
-
-    std::vector<uint8_t> buffer;
-
-    while (dir_iter != std::filesystem::directory_iterator{})
-    {
-        const bool is_file = dir_iter->is_regular_file(ec);
-        if (ec)
-        {
-            //fprintf(stderr,
-            //        "Failed to check file type of `%s`: %s\n",
-            //        dir_iter->path().generic_string().c_str(),
-            //        ec.message().c_str());
-            return false;
-        }
-
-        if (!is_file)
-        {
-            dir_iter.increment(ec);
-            if (ec)
-            {
-                //fprintf(stderr, "Failed to get next file: %s\n", ec.message().c_str());
-                return false;
-            }
-            continue;
-        }
-
-        const uintmax_t file_size = dir_iter->file_size(ec);
-        if (ec)
-        {
-            //fprintf(stderr,
-            //        "Failed to get file size of `%s`: %s\n",
-            //        dir_iter->path().generic_string().c_str(),
-            //        ec.message().c_str());
-            return false;
-        }
-
-        // Skip files larger than 4MB
-        if (file_size > (uintmax_t)(4 * 1024 * 1024))
-        {
-            dir_iter.increment(ec);
-            if (ec)
-            {
-                //fprintf(stderr, "Failed to get next file: %s\n", ec.message().c_str());
-                return false;
-            }
-            continue;
-        }
-
-        ReadAllBytes(dir_iter->path(), buffer);
-
-        SHA256Context ctx;
-        SHA256Digest  digest_bytes;
-
-        SHA256Reset(&ctx);
-        SHA256Input(&ctx, buffer.data(), (unsigned int)buffer.size());
-        SHA256Result(&ctx, digest_bytes.data());
-
-        for (const auto& known : ROM_HASHES)
-        {
-            if (known.hash == digest_bytes && !all_info.romsets[(size_t)known.romset].HasRom(known.location))
-            {
-                all_info.romsets[(size_t)known.romset].rom_paths[(size_t)known.location] = dir_iter->path();
-
-                if (desired && (*desired)[(size_t)known.location])
-                {
-                    auto& rom_data = all_info.romsets[(size_t)known.romset].rom_data[(size_t)known.location];
-                    if (IsWaverom(known.location))
-                    {
-                        rom_data.resize(buffer.size());
-                        unscramble(rom_data.data(), buffer.data(), (int)buffer.size());
-                    }
-                    else
-                    {
-                        rom_data = std::move(buffer);
-                        buffer   = {};
-                    }
-                }
-            }
-        }
-
-        dir_iter.increment(ec);
-        if (ec)
-        {
-            //fprintf(stderr, "Failed to get next file: %s\n", ec.message().c_str());
-            return false;
-        }
-    }
-
-    return true;
-}
-
-bool IsCompleteRomset(const AllRomsetInfo& all_info, Romset romset, RomCompletionStatusSet* status)
-{
-    bool is_complete = true;
-
     if (status)
     {
         status->fill(RomCompletionStatus::Unused);
     }
 
-    const auto& info = all_info.romsets[(size_t)romset];
+    bool is_complete = true;
 
-    for (const auto& known : ROM_HASHES)
+    for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
     {
-        if (known.romset != romset)
+        const RomLocation location = (RomLocation)i;
+        if (IsRequiredRom(romset, location) && info.HasRom(location))
+        {
+            (*status)[i] = RomCompletionStatus::Present;
+        }
+        else if (IsRequiredRom(romset, location) && !info.HasRom(location))
+        {
+            (*status)[i] = RomCompletionStatus::Missing;
+            is_complete  = false;
+        }
+    }
+
+    return is_complete;
+}
+
+bool GetDefinitionCompletion(const RomsetDefinition&   def,
+                             const HashedFileRegistry& hashed_files,
+                             const RomLocationSet&     location_mask,
+                             RomCompletionStatusSet&   completion)
+{
+    completion.fill(RomCompletionStatus::Unused);
+
+    bool is_complete = true;
+
+    for (RomLocation rom : def.GetValidLocations())
+    {
+        if (!location_mask[(size_t)rom])
         {
             continue;
         }
 
-        if (!info.HasRom(known.location) && !IsOptionalRom(romset, known.location))
+        if (hashed_files.Contains(def.GetHash(rom)))
         {
-            is_complete = false;
-            if (status)
-            {
-                (*status)[(size_t)known.location] = RomCompletionStatus::Missing;
-            }
+            completion[(size_t)rom] = RomCompletionStatus::Present;
         }
-        else if (info.HasRom(known.location))
+        else
         {
-            if (status)
-            {
-                (*status)[(size_t)known.location] = RomCompletionStatus::Present;
-            }
+            completion[(size_t)rom] = RomCompletionStatus::Missing;
+            is_complete             = false;
         }
     }
 
@@ -720,64 +276,25 @@ size_t CountPresent(const RomCompletionStatusSet& status)
     return count;
 }
 
-bool PickCompleteRomset(const AllRomsetInfo& all_info, Romset& out_romset)
+void SetRomsetFilenames(RomsetInfo&                  romset_info,
+                        const std::filesystem::path& base_path,
+                        Romset                       romset,
+                        const RomLocationSet&        location_mask)
 {
-    for (size_t i = 0; i < ROMSET_COUNT; ++i)
+    for (size_t rom = 0; rom < ROMLOCATION_COUNT; ++rom)
     {
-        if (IsCompleteRomset(all_info, (Romset)i))
-        {
-            out_romset = (Romset)i;
-            return true;
-        }
-    }
-    return false;
-}
-
-bool DetectRomsetsByFilename(const std::filesystem::path& base_path,
-                                 AllRomsetInfo&           all_info,
-                                 RomLocationSet*          desired)
-{
-    for (size_t romset = 0; romset < ROMSET_COUNT; ++romset)
-    {
-        if (desired && !(*desired)[romset])
+        if (legacy_rom_names[(size_t)romset][rom][0] == '\0')
         {
             continue;
         }
 
-        for (size_t rom = 0; rom < ROMLOCATION_COUNT; ++rom)
+        if (!location_mask[rom])
         {
-            if (legacy_rom_names[romset][rom][0] == '\0')
-            {
-                continue;
-            }
-
-            std::filesystem::path rom_path = base_path / legacy_rom_names[romset][rom];
-
-            all_info.romsets[romset].rom_paths[rom] = std::move(rom_path);
+            continue;
         }
+
+        romset_info.rom_paths[rom] = base_path / legacy_rom_names[(size_t)romset][rom];
     }
-
-    return true;
-}
-
-bool ReadStreamExact(std::ifstream& s, void* into, std::streamsize byte_count)
-{
-    if (s.read((char*)into, byte_count))
-    {
-        return s.gcount() == byte_count;
-    }
-    return false;
-}
-
-bool ReadStreamExact(std::ifstream& s, std::span<uint8_t> into, std::streamsize byte_count)
-{
-    return ReadStreamExact(s, into.data(), byte_count);
-}
-
-std::streamsize ReadStreamUpTo(std::ifstream& s, void* into, std::streamsize byte_count)
-{
-    s.read((char*)into, byte_count);
-    return s.gcount();
 }
 
 void RomsetInfo::PurgeRomData()
@@ -793,22 +310,12 @@ bool RomsetInfo::HasRom(RomLocation location) const
     return !(rom_paths[(size_t)location].empty() && rom_data[(size_t)location].empty());
 }
 
-void AllRomsetInfo::PurgeRomData()
-{
-    for (auto& romset : romsets)
-    {
-        romset.PurgeRomData();
-    }
-}
-
-bool LoadRomset(Romset romset, AllRomsetInfo& all_info, RomLoadStatusSet* loaded)
+bool LoadRomset(RomsetInfo& info, RomLoadStatusSet* loaded)
 {
     bool all_loaded = true;
 
     // We cannot unscramble in-place.
     std::vector<uint8_t> on_demand_buffer;
-
-    RomsetInfo& info = all_info.romsets[(size_t)romset];
 
     for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
     {
@@ -824,7 +331,7 @@ bool LoadRomset(Romset romset, AllRomsetInfo& all_info, RomLoadStatusSet* loaded
         }
         else if (!info.rom_paths[i].empty() && info.rom_data[i].empty())
         {
-            if (!ReadAllBytes(info.rom_paths[i], on_demand_buffer))
+            if (!FIO_ReadAllBytes(info.rom_paths[i], on_demand_buffer))
             {
                 all_loaded = false;
                 if (loaded)
@@ -852,6 +359,13 @@ bool LoadRomset(Romset romset, AllRomsetInfo& all_info, RomLoadStatusSet* loaded
         }
         else if (!info.rom_data[i].empty())
         {
+            if (IsWaverom(location))
+            {
+                on_demand_buffer.resize(info.rom_data[i].size());
+                unscramble(info.rom_data[i].data(), on_demand_buffer.data(), (int)on_demand_buffer.size());
+                std::swap(info.rom_data[i], on_demand_buffer);
+            }
+
             if (loaded)
             {
                 (*loaded)[i] = RomLoadStatus::Loaded;
@@ -888,4 +402,122 @@ const char* ToCString(RomCompletionStatus status)
         return "Unused";
     }
     return "Unknown status";
+}
+
+void GetCompleteRomsetNames(const RomsetRegistry&     romsets,
+                            const HashedFileRegistry& hashed_files,
+                            const RomLocationSet&     location_mask,
+                            StringVector&             out_names)
+{
+    out_names.clear();
+    for (const auto& romset : romsets)
+    {
+        bool is_complete = true;
+        for (RomLocation location : romset.GetValidLocations())
+        {
+            if (location_mask[(size_t)location] && !hashed_files.Contains(romset.GetHash(location)))
+            {
+                is_complete = false;
+                break;
+            }
+        }
+        if (is_complete)
+        {
+            out_names.push_back(romset.name);
+        }
+    }
+}
+
+void GetPartialRomsetNames(const RomsetRegistry&     romsets,
+                           const HashedFileRegistry& hashed_files,
+                           const RomLocationSet&     location_mask,
+                           StringVector&             out_names)
+{
+    out_names.clear();
+    for (const auto& romset : romsets)
+    {
+        bool is_partial = false;
+        for (RomLocation location : romset.GetValidLocations())
+        {
+            if (location_mask[(size_t)location] && hashed_files.Contains(romset.GetHash(location)))
+            {
+                is_partial = true;
+                break;
+            }
+        }
+        if (is_partial)
+        {
+            out_names.push_back(romset.name);
+        }
+    }
+}
+
+bool ContainsRomsetFiles(const RomsetRegistry&     romsets,
+                         std::string_view          name,
+                         const HashedFileRegistry& hashed_files,
+                         const RomLocationSet&     location_mask)
+{
+    const RomsetDefinition* def = romsets.GetDefinition(name);
+
+    if (!def)
+    {
+        return false;
+    }
+
+    bool is_complete = true;
+
+    for (RomLocation location : def->GetValidLocations())
+    {
+        if (location_mask[(size_t)location] && !hashed_files.Contains(def->GetHash(location)))
+        {
+            is_complete = false;
+            break;
+        }
+    }
+
+    return is_complete;
+}
+
+bool GetRomsetInfo(const RomsetRegistry&     romsets,
+                   std::string_view          name,
+                   const HashedFileRegistry& hashed_files,
+                   const RomLocationSet&     location_mask,
+                   RomsetInfo&               out_info)
+{
+    const RomsetDefinition* def = romsets.GetDefinition(name);
+
+    if (!def)
+    {
+        return false;
+    }
+
+    bool is_complete = true;
+
+    for (RomLocation location : def->GetValidLocations())
+    {
+        if (!location_mask[(size_t)location])
+        {
+            continue;
+        }
+
+        const HashedFile* hf = hashed_files.GetFile(def->GetHash(location));
+
+        if (!hf)
+        {
+            is_complete = false;
+            continue;
+        }
+
+        out_info.rom_paths[(size_t)location] = hf->path;
+        // TODO: This is a large buffer copy. In practice this probably doesn't matter because we should only have ~5
+        // roms on average and most of them will be small. It is difficult to avoid this for two reasons: 1) we need to
+        // unscramble waveroms which needs a second buffer allocation anyways, and 2) RomsetInfo is also acting as
+        // storage for roms which will likely be shared between emulator instances in the future. We will not be able
+        // to point into the file registry when sharing is enabled, because again, we need to unscramble waveroms. The
+        // final design should probably allocate one contiguous buffer to hold all roms for better locality. Then we
+        // copy all of the roms into that buffer, unscrambling the waveroms at that point.
+        out_info.rom_data[(size_t)location] = hf->data;
+    }
+
+    return is_complete;
 }

--- a/src/nuked-sc55/backend/rom_io.h
+++ b/src/nuked-sc55/backend/rom_io.h
@@ -1,8 +1,12 @@
 #pragma once
 
-#include "rom.h"
+#include <array>
 #include <filesystem>
 #include <vector>
+
+#include "rom.h"
+
+class HashedFileRegistry;
 
 enum class RomLoadStatus
 {
@@ -48,53 +52,77 @@ struct RomsetInfo
     bool HasRom(RomLocation location) const;
 };
 
-// Contains RomsetInfo for all supported romsets.
-struct AllRomsetInfo
-{
-    // Array indexed by Romset
-    RomsetInfo romsets[ROMSET_COUNT]{};
-
-    // Release all rom_data for all romsets.
-    void PurgeRomData();
-};
-
-// Scans files in `base_path` for specific rom filenames. Consult the `legacy_rom_names` constant in `emu.cpp` for the
-// exact filename requirements.
+// Sets `romset_info.rom_paths` relative to `base_path` using filenames for `romset`. Consult the `legacy_rom_names`
+// constant in `rom_io.cpp` for the exact filenames.
 //
-// If `desired` is non-null, this function will use it as a hint to determine what filenames to examine. This function
-// may also load `rom_data` for desired roms.
-bool DetectRomsetsByFilename(const std::filesystem::path& base_path,
-                             AllRomsetInfo&               all_info,
-                             RomLocationSet*              desired = nullptr);
+// `location_mask` can be used to control which rom locations are populated. A value of `true` sets the corresponding
+// path if it is used by the romset; otherwise that path will be skipped.
+void SetRomsetFilenames(RomsetInfo&                  romset_info,
+                        const std::filesystem::path& base_path,
+                        Romset                       romset,
+                        const RomLocationSet&        location_mask);
 
-// Scans files in `base_path` for roms by hashing them. The locations of each rom will be made available in `info`. This
-// will return *all* romsets in `base_path`.
-//
-// If any of the rom locations in `all_info` are already populated with a path or data, this function will not overwrite
-// them.
-//
-// If `desired` is non-null, this function will use it as a hint to determine what hashes to consider. This function may
-// also load `rom_data` for desired roms.
-bool DetectRomsetsByHash(const std::filesystem::path& base_path,
-                         AllRomsetInfo&               all_info,
-                         RomLocationSet*              desired = nullptr);
-
-// Returns true if `all_info` contains all the files required to load `romset`. Missing roms will be reported in
+// Returns true if `info` contains all the files required to load `romset`. Missing roms will be reported in
 // `missing`.
-bool IsCompleteRomset(const AllRomsetInfo& all_info, Romset romset, RomCompletionStatusSet* status = nullptr);
+bool IsCompleteRomset(const RomsetInfo& info, Romset romset, RomCompletionStatusSet* status = nullptr);
+
+// Similar to `IsCompleteRomset`, except this function operates on `RomsetDefinition` which may be known earlier than a
+// `RomsetInfo` is available.
+bool GetDefinitionCompletion(const RomsetDefinition&   def,
+                             const HashedFileRegistry& hashed_files,
+                             const RomLocationSet&     location_mask,
+                             RomCompletionStatusSet&   completion);
 
 size_t CountPresent(const RomCompletionStatusSet& status);
 
-// Picks the first complete romset in `all_info` and writes it to `out_romset`. If multiple romsets are present, the one
-// returned is unspecified. Returns true if successful, or false if there are no complete romsets.
-bool PickCompleteRomset(const AllRomsetInfo& all_info, Romset& out_romset);
-
-// For each `rom` in `romset`, this function loads the file referenced by `all_info.romsets[romset].rom_paths[rom]` into
-// the corresponding `rom_data`. Waveroms will be unscrambled at this point.
+// For each `rom` in `info` this function loads the file referenced by `info.rom_paths[rom]` into `info.rom_data[rom]`.
+// If `info.rom_data[rom]` is already populated, no data will be loaded from disk.
+//
+// Waveroms will be unscrambled at this point. If `info.rom_data[rom]` is provided by the caller, it should *not* be
+// provided unscrambled.
 //
 // `rom` will only be loaded when `rom_data` is empty and `rom_path` is non-empty.
 //
-// To automatically determine rom_paths, call `DetectRomsetsByHash` with a directory containing roms.
+// To automatically determine elements of `rom_path`, populate a `HashedFileRegistry` and `RomsetRegistry` then
+// use the `RomsetRegistry` to look up a specific romset in the `HashedFileRegistry`.
+bool LoadRomset(RomsetInfo& info, RomLoadStatusSet* loaded);
+
+// Returns romsets identifiers whose complete romsets are contained in `hashed_files`. `location_mask` can be used
+// to filter which roms are considered for the completeness of the romset. The test logic works the same as in
+// `ContainsRomsetFiles`. `out_names` will be cleared before receiving the names.
+void GetCompleteRomsetNames(const RomsetRegistry&     romsets,
+                            const HashedFileRegistry& hashed_files,
+                            const RomLocationSet&     location_mask,
+                            StringVector&             out_names);
+
+// Returns romsets identifiers whose partial romsets are contained in `hashed_files`. `location_mask` can be used
+// to filter which roms are considered for the completeness of the romset. The test logic works the same as in
+// `ContainsRomsetFiles`. `out_names` will be cleared before receiving the names.
+void GetPartialRomsetNames(const RomsetRegistry&     romsets,
+                           const HashedFileRegistry& hashed_files,
+                           const RomLocationSet&     location_mask,
+                           StringVector&             out_names);
+
+// Returns true if all the roms in the romset named `name` is in `hashed_files`.
 //
-// Roms that were loaded successfully will be marked as true in `loaded`.
-bool LoadRomset(Romset romset, AllRomsetInfo& all_info, RomLoadStatusSet* loaded = nullptr);
+// `location_mask` allows the caller to control which roms will be tested. For rom locations used by the romset, a
+// value of `true` enables the test and a value of `false` disables the test. The test succeeds if the hash for
+// that location is in `hashed_files`. If a rom location is not used by the romset, the value is ignored.
+bool ContainsRomsetFiles(const RomsetRegistry&     romsets,
+                         std::string_view          name,
+                         const HashedFileRegistry& hashed_files,
+                         const RomLocationSet&     location_mask);
+
+// If the romset given by `name` exists, `out_info` receives the paths and data contained for each rom in the
+// romset.
+//
+// `location_mask` allows the caller to control which roms will be returned. The test logic works the same way as
+// in `ContainsRomsetFiles`.
+//
+// Returns true if the definition exists and all the required roms exist in `hashed_files`. If this function returns
+// false, `out_info` will still be populated with the contents of any roms that were found.
+bool GetRomsetInfo(const RomsetRegistry&     romsets,
+                   std::string_view          name,
+                   const HashedFileRegistry& hashed_files,
+                   const RomLocationSet&     location_mask,
+                   RomsetInfo&               out_info);

--- a/src/nuked-sc55/backend/sha256.h
+++ b/src/nuked-sc55/backend/sha256.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <span>
+
+extern "C"
+{
+#include "sha/sha.h"
+}
+
+using SHA256_Digest = std::array<uint8_t, 32>;
+
+template <>
+struct std::hash<SHA256_Digest>
+{
+    size_t operator()(const SHA256_Digest& digest) const
+    {
+        size_t result = 0;
+        for (size_t i = 0; i < sizeof(SHA256_Digest) / sizeof(size_t); ++i)
+        {
+            size_t block;
+            memcpy(&block, &digest[i * sizeof(size_t)], sizeof(size_t));
+            result ^= block;
+        }
+        return result;
+    }
+};
+
+namespace detail
+{
+consteval uint8_t HexValue(char x)
+{
+    if (x >= '0' && x <= '9')
+    {
+        return (uint8_t)(x - '0');
+    }
+    else if (x >= 'a' && x <= 'f')
+    {
+        return 10 + (uint8_t)(x - 'a');
+    }
+    else
+    {
+        throw "character out of range";
+    }
+}
+} // namespace detail
+
+// Compile time string-to-SHA256_Digest
+template <size_t N>
+consteval SHA256_Digest SHA256_ToDigest(const char (&s)[N])
+{
+    static_assert(N == 65); // 64 + null terminator
+
+    SHA256_Digest hash;
+    for (size_t i = 0; i < N / 2; ++i)
+    {
+        hash[i] = (uint8_t)((detail::HexValue(s[2 * i + 0]) << 4) | detail::HexValue(s[2 * i + 1]));
+    }
+
+    return hash;
+}
+
+inline bool SHA256_HashBytes(std::span<uint8_t> bytes, SHA256_Digest& out_digest)
+{
+    SHA256Context ctx;
+
+    int err;
+
+    err = SHA256Reset(&ctx);
+    if (err != shaSuccess)
+    {
+        return false;
+    }
+
+    err = SHA256Input(&ctx, bytes.data(), (unsigned int)bytes.size());
+    if (err != shaSuccess)
+    {
+        return false;
+    }
+
+    err = SHA256Result(&ctx, out_digest.data());
+    if (err != shaSuccess)
+    {
+        return false;
+    }
+
+    return true;
+}

--- a/src/nuked-sc55/backend/standard_romsets.cpp
+++ b/src/nuked-sc55/backend/standard_romsets.cpp
@@ -1,0 +1,425 @@
+#include "rom.h"
+
+// clang-format off
+
+// TODO: Backwards compat to avoid messy diff.
+#define ToDigest SHA256_ToDigest
+
+// TODO: These will be removed from the standard romset list in the future.
+constexpr RomsetDefinition CTF_TEMPLATE = {
+    .name = "",
+    .romset = Romset::MK2,
+    .hashes = {
+        // R15199858 (H8/532 mcu)
+        {ToDigest("8a1eb33c7599b746c0c50283e4349a1bb1773b5c0ec0e9661219bf6c067d2042"), RomLocation::ROM1},
+        // R00233567 (H8/532 extra code)
+        {ToDigest("a4c9fd821059054c7e7681d61f49ce6f42ed2fe407a7ec1ba0dfdc9722582ce0"), RomLocation::ROM2},
+        // R15199880 (M37450M2 mcu)
+        {ToDigest("b0b5f865a403f7308b4be8d0ed3ba2ed1c22db881b8a8326769dea222f6431d8"), RomLocation::SMROM},
+        // R15209359 (WAVE 16M)
+        {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), RomLocation::WAVEROM1},
+        // R15279813 (WAVE 8M)
+        {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), RomLocation::WAVEROM2},
+    },
+};
+
+// CTF patched roms from https://github.com/shingo45endo/sc55mk2-ctf-patcher
+//
+// To register these hashes we copy either the MK2 or SC155MK2 romset-hashes
+// pair above and replace ROM2 with one of the following hashes.
+constexpr std::array<SHA256_Digest, 6> CTF_ROM2_HASHES = {
+    // Tone: Strict SC-55 | Drum: SC-55 v1.21 or earlier
+    ToDigest("64f8c9daf1021cf86ea4ddf03a29b81b5ea0c18e74f462833023436388bb9dc4"),
+    // Tone: Strict SC-55 | Drum: SC-55 v2.00
+    ToDigest("14d14778caf46ffa9e3d608aa8e9c1a60c32bd4a536c26af3b2e1d81784c60f9"),
+    // Tone: SC-55 | Drum: SC-55 v1.21 or earlier
+    ToDigest("10b3f09485a74bb014f1a940d5c67f380c7979b62891d540d788154c83f17430"),
+    // Tone: SC-55 | Drum: SC-55 v2.00
+    ToDigest("a2c720be1ab9115930d27f821a413c0366b7bf0c4ddfe0dadc5086136a1a4345"),
+    // Tone: SC-55mkII | Drum: SC-55 v1.21 or earlier
+    ToDigest("16cec615da10089beffe6de5129ba8ba33fa1bf017a5e6b78ad1d6d15cf4708e"),
+    // Tone: SC-55mkII | Drum: SC-55 v2.00
+    ToDigest("c22bf7d34a3406530924d750b007bbdb470f3216c65086edb6e53023383ee907"),
+};
+
+// 0 - MK2
+// 1 - SC155MK2
+//
+// See AddCtfPatchedHashes function.
+constexpr const char* CTF_ROMSET_NAMES[2][CTF_ROM2_HASHES.size()] = {
+    {
+        "mk2-ctf-strict-sc55-drum-sc55-v1.21",
+        "mk2-ctf-strict-sc55-drum-sc55-v2.00",
+        "mk2-ctf-sc55-drum-sc55-v1.21",
+        "mk2-ctf-sc55-drum-sc55-v2.00",
+        "mk2-ctf-mk2-drum-sc55-v1.21",
+        "mk2-ctf-mk2-drum-sc55-v2.00",
+    },
+    {
+        "sc155mk2-ctf-strict-sc55-drum-sc55-v1.21",
+        "sc155mk2-ctf-strict-sc55-drum-sc55-v2.00",
+        "sc155mk2-ctf-sc55-drum-sc55-v1.21",
+        "sc155mk2-ctf-sc55-drum-sc55-v2.00",
+        "sc155mk2-ctf-mk2-drum-sc55-v1.21",
+        "sc155mk2-ctf-mk2-drum-sc55-v2.00",
+    },
+};
+
+consteval RomsetDefinition MakeCtf(Romset romset, size_t variant)
+{
+    size_t which_table;
+    switch (romset)
+    {
+    case Romset::MK2:
+        which_table = 0;
+        break;
+    case Romset::SC155MK2:
+        which_table = 1;
+        break;
+    default:
+        throw "invalid romset";
+    }
+
+    RomsetDefinition result = CTF_TEMPLATE;
+    result.ReplaceHash(RomLocation::ROM2, CTF_ROM2_HASHES[variant]);
+    result.name = CTF_ROMSET_NAMES[which_table][variant];
+    result.romset = romset;
+    return result;
+}
+
+constexpr RomsetDefinition STANDARD_ROMSET_DEFS[] = {
+    ///////////////////////////////////////////////////////////////////////////
+    // SC-55mk2/SC-155mk2 (v1.01)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "mk2-v1.01",
+        .romset = Romset::MK2,
+        .hashes = {
+            // R15199858 (H8/532 mcu)
+            {ToDigest("8a1eb33c7599b746c0c50283e4349a1bb1773b5c0ec0e9661219bf6c067d2042"), RomLocation::ROM1},
+            // R00233567 (H8/532 extra code)
+            {ToDigest("a4c9fd821059054c7e7681d61f49ce6f42ed2fe407a7ec1ba0dfdc9722582ce0"), RomLocation::ROM2},
+            // R15199880 (M37450M2 mcu)
+            {ToDigest("b0b5f865a403f7308b4be8d0ed3ba2ed1c22db881b8a8326769dea222f6431d8"), RomLocation::SMROM},
+            // R15209359 (WAVE 16M)
+            {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), RomLocation::WAVEROM1},
+            // R15279813 (WAVE 8M)
+            {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), RomLocation::WAVEROM2},
+        },
+    },
+
+    {
+        .name = "sc155mk2-v1.01",
+        .romset = Romset::SC155MK2,
+        .hashes = {
+            // R15199858 (H8/532 mcu)
+            {ToDigest("8a1eb33c7599b746c0c50283e4349a1bb1773b5c0ec0e9661219bf6c067d2042"), RomLocation::ROM1},
+            // R00233567 (H8/532 extra code)
+            {ToDigest("a4c9fd821059054c7e7681d61f49ce6f42ed2fe407a7ec1ba0dfdc9722582ce0"), RomLocation::ROM2},
+            // R15199880 (M37450M2 mcu)
+            {ToDigest("b0b5f865a403f7308b4be8d0ed3ba2ed1c22db881b8a8326769dea222f6431d8"), RomLocation::SMROM},
+            // R15209359 (WAVE 16M)
+            {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), RomLocation::WAVEROM1},
+            // R15279813 (WAVE 8M)
+            {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), RomLocation::WAVEROM2},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // SC-55st (v1.01)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "st-v1.01",
+        .romset = Romset::ST,
+        .hashes = {
+            // R15199858 (H8/532 mcu)
+            {ToDigest("8a1eb33c7599b746c0c50283e4349a1bb1773b5c0ec0e9661219bf6c067d2042"), RomLocation::ROM1},
+            // R00561413 (H8/532 extra code)
+            {ToDigest("03517ac0a3b1ad8b69a1a4ee045e0c21da0170027bd1ba1bd3cf72cd017bbe6a"), RomLocation::ROM2},
+            // R15199880 (M37450M2 mcu)
+            {ToDigest("b0b5f865a403f7308b4be8d0ed3ba2ed1c22db881b8a8326769dea222f6431d8"), RomLocation::SMROM},
+            // R15209359 (WAVE 16M)
+            {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), RomLocation::WAVEROM1},
+            // R15279813 (WAVE 8M)
+            {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), RomLocation::WAVEROM2},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // SC-55 (v1.00)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "mk1-v1.00",
+        .romset = Romset::MK1,
+        .hashes = {
+            // R15199748 (H8/532 mcu)
+            {ToDigest("b4ecf44bc0520322b0d114d397951d3bf92ca6fa51d0d27b2407df58a6be2efe"), RomLocation::ROM1},
+            // R15449258 (H8/532 extra code)
+            {ToDigest("014e2e21ea30de7a1e4f1cdea14dd9a719960535e257a9e40e98dbb1a5870226"), RomLocation::ROM2},
+            // R15209276 (WAVE A)
+            {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), RomLocation::WAVEROM1},
+            // R15209277 (WAVE B)
+            {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), RomLocation::WAVEROM2},
+            // R15209281 (WAVE C)
+            {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), RomLocation::WAVEROM3},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // SC-55 (v1.10)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "mk1-v1.10",
+        .romset = Romset::MK1,
+        .hashes = {
+            // R15199736 (H8/532 mcu)
+            {ToDigest("2fe88ec39f3ef4b1de8cdf74527419467975c47f7aacfcd07605e01d54bd89b5"), RomLocation::ROM1},
+            // R15209275 (H8/532 extra code)
+            {ToDigest("ec064d6c4fc70ec990911089d966043cb819fba0e26e6f6afdd0a05e5301b91b"), RomLocation::ROM2},
+            // R15209276 (WAVE A)
+            {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), RomLocation::WAVEROM1},
+            // R15209277 (WAVE B)
+            {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), RomLocation::WAVEROM2},
+            // R15209281 (WAVE C)
+            {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), RomLocation::WAVEROM3},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // SC-55 (v1.20)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "mk1-v1.20",
+        .romset = Romset::MK1,
+        .hashes = {
+            // R15199778 (H8/532 mcu)
+            {ToDigest("7e1bacd1d7c62ed66e465ba05597dcd60dfc13fc23de0287fdbce6cf906c6544"), RomLocation::ROM1},
+            // R15209337 (H8/532 extra code)
+            {ToDigest("22ce6ca59e6332143b335525e81fab501ea6fccce4b7e2f3bfc2cc8bf6612ff6"), RomLocation::ROM2},
+            // R15209276 (WAVE A)
+            {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), RomLocation::WAVEROM1},
+            // R15209277 (WAVE B)
+            {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), RomLocation::WAVEROM2},
+            // R15209281 (WAVE C)
+            {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), RomLocation::WAVEROM3},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // SC-55 (v1.21)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "mk1-v1.21",
+        .romset = Romset::MK1,
+        .hashes = {
+            // R15199778 (H8/532 mcu)
+            {ToDigest("7e1bacd1d7c62ed66e465ba05597dcd60dfc13fc23de0287fdbce6cf906c6544"), RomLocation::ROM1},
+            // R15209363 (H8/532 extra code)
+            {ToDigest("effc6132d68f7e300aaef915ccdd08aba93606c22d23e580daf9ea6617913af1"), RomLocation::ROM2},
+            // R15209276 (WAVE A)
+            {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), RomLocation::WAVEROM1},
+            // R15209277 (WAVE B)
+            {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), RomLocation::WAVEROM2},
+            // R15209281 (WAVE C)
+            {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), RomLocation::WAVEROM3},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // SC-55 (v2.00)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "mk1-v2.00",
+        .romset = Romset::MK1,
+        .hashes = {
+            // R15199799 (H8/532 mcu)
+            {ToDigest("24a65c97cdbaa847d6f59193523ce63c73394b4b693a6517ee79441f2fb8a3ee"), RomLocation::ROM1},
+            // R15209387 (H8/532 extra code)
+            {ToDigest("f5dac35d450ab986570a209dff3816eec75cee669e161f54b51224b467dd0bcc"), RomLocation::ROM2},
+            // R15209276 (WAVE A)
+            {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), RomLocation::WAVEROM1},
+            // R15209277 (WAVE B)
+            {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), RomLocation::WAVEROM2},
+            // R15209281 (WAVE C)
+            {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), RomLocation::WAVEROM3},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CM-300/SCC-1 (v1.10)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "cm300-v1.10",
+        .romset = Romset::CM300,
+        .hashes = {
+            // R15199774 (H8/532 mcu)
+            {ToDigest("72ed35481efbf25b3c492b83183655d17a3b266ecb30ffbc6dc977e6a8d261b2"), RomLocation::ROM1},
+            // R15279809 (H8/532 extra code)
+            {ToDigest("0283d32e6993a0265710c4206463deb937b0c3a4819b69f471a0eca5865719f9"), RomLocation::ROM2},
+            // R15279806 (WAVE A)
+            {ToDigest("40c093cbfb4441a5c884e623f882a80b96b2527f9fd431e074398d206c0f073d"), RomLocation::WAVEROM1},
+            // R15279807 (WAVE B)
+            {ToDigest("9bbbcac747bd6f7a2693f4ef10633db8ab626f17d3d9c47c83c3839d4dd2f613"), RomLocation::WAVEROM2},
+            // R15279808 (WAVE C)
+            {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), RomLocation::WAVEROM3},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // CM-300/SCC-1 (v1.20)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "cm300-v1.20",
+        .romset = Romset::CM300,
+        .hashes = {
+            // R15199774 (H8/532 mcu)
+            {ToDigest("72ed35481efbf25b3c492b83183655d17a3b266ecb30ffbc6dc977e6a8d261b2"), RomLocation::ROM1},
+            // R15279812 (H8/532 extra code)
+            {ToDigest("fef1acb1969525d66238be5e7811108919b07a4df5fbab656ad084966373483f"), RomLocation::ROM2},
+            // R15279806 (WAVE A)
+            {ToDigest("40c093cbfb4441a5c884e623f882a80b96b2527f9fd431e074398d206c0f073d"), RomLocation::WAVEROM1},
+            // R15279807 (WAVE B)
+            {ToDigest("9bbbcac747bd6f7a2693f4ef10633db8ab626f17d3d9c47c83c3839d4dd2f613"), RomLocation::WAVEROM2},
+            // R15279808 (WAVE C)
+            {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), RomLocation::WAVEROM3},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // SCC-1A (v1.30)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        // TODO: check header comment and revise name
+        .name = "cm300-v1.30",
+        .romset = Romset::CM300,
+        .hashes = {
+            // R00128523 (H8/532 mcu)
+            {ToDigest("9ec66abb5231b6c6f46f48b33d5412703041037d69a6803626ac402f25552af2"), RomLocation::ROM1},
+            // R00128567 (H8/532 extra code)
+            {ToDigest("f89442734fdebacae87c7707c01b2d7fdbf5940abae738987aee912d34b5882e"), RomLocation::ROM2},
+            // R15279806 (WAVE A)
+            {ToDigest("40c093cbfb4441a5c884e623f882a80b96b2527f9fd431e074398d206c0f073d"), RomLocation::WAVEROM1},
+            // R15279807 (WAVE B)
+            {ToDigest("9bbbcac747bd6f7a2693f4ef10633db8ab626f17d3d9c47c83c3839d4dd2f613"), RomLocation::WAVEROM2},
+            // R15279808 (WAVE C)
+            {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), RomLocation::WAVEROM3},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // JV-880 (v1.0.0)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "jv880-v1.0.0",
+        .romset = Romset::JV880,
+        .hashes = {
+            // R15199810 (H8/532 mcu)
+            {ToDigest("aabfcf883b29060198566440205f2fae1ce689043ea0fc7074842aaa4fd4823e"), RomLocation::ROM1},
+            // R15209386 (H8/532 extra code)
+            {ToDigest("11852e60ff597633c754c5441c1e3e06793bcd951fcea2c4969ac3041d130fce"), RomLocation::ROM2},
+            // R15209312 (WAVE A)
+            {ToDigest("aa3101a76d57992246efeda282a2cb0c0f8fdb441c2eed2aa0b0fad4d81f3ad4"), RomLocation::WAVEROM1},
+            // R15209313 (WAVE B)
+            {ToDigest("a7b50bb47734ee9117fa16df1f257990a9a1a0b5ed420337ae4310eb80df75c8"), RomLocation::WAVEROM2},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // JV-880 (v1.0.1)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "jv880-v1.0.1",
+        .romset = Romset::JV880,
+        .hashes = {
+            // R15199810 (H8/532 mcu)
+            {ToDigest("aabfcf883b29060198566440205f2fae1ce689043ea0fc7074842aaa4fd4823e"), RomLocation::ROM1},
+            // R15209481 (H8/532 extra code)
+            {ToDigest("ed437f1bc75cc558f174707bcfeb45d5e03483efd9bfd0a382ca57c0edb2a40c"), RomLocation::ROM2},
+            // R15209312 (WAVE A)
+            {ToDigest("aa3101a76d57992246efeda282a2cb0c0f8fdb441c2eed2aa0b0fad4d81f3ad4"), RomLocation::WAVEROM1},
+            // R15209313 (WAVE B)
+            {ToDigest("a7b50bb47734ee9117fa16df1f257990a9a1a0b5ed420337ae4310eb80df75c8"), RomLocation::WAVEROM2},
+        },
+    },
+
+    // TODO: missing jv880 optional roms
+
+    ///////////////////////////////////////////////////////////////////////////
+    // SCB-55/RLP-3194
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "scb55-v2.00",
+        .romset = Romset::SCB55,
+        .hashes = {
+            // R15199827 (H8/532 mcu)
+            {ToDigest("00df835d3f97fc8b0059db63f36d608eec2bfd1f51ad54eb5af52c868c1111b1"), RomLocation::ROM1},
+            // R15279828 (H8/532 extra code)
+            {ToDigest("541be4d0b1ef0d07bb042ba67ffd099c8a5d746aac4cd24ce8842c034379f213"), RomLocation::ROM2},
+            // R15209359 (WAVE 16M)
+            {ToDigest("c6429e21b9b3a02fbd68ef0b2053668433bee0bccd537a71841bc70b8874243b"), RomLocation::WAVEROM1},
+            // R15279813 (WAVE 8M)
+            {ToDigest("5b753f6cef4cfc7fcafe1430fecbb94a739b874e55356246a46abe24097ee491"), RomLocation::WAVEROM3},
+            // ^NOTE: legacy loader looks for a file called wav "scb55_waverom2.bin", but during loading it is actually placed in WAVEROM3
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // RLP-3237
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "rlp3237-v2.01",
+        .romset = Romset::RLP3237,
+        .hashes = {
+            // R15199827 (H8/532 mcu)
+            {ToDigest("00df835d3f97fc8b0059db63f36d608eec2bfd1f51ad54eb5af52c868c1111b1"), RomLocation::ROM1},
+            // R15209486 (H8/532 extra code)
+            {ToDigest("e0a3d6d9b05e82374a0d289901273ce560ce1ead86459c75f844158b32d204a9"), RomLocation::ROM2},
+            // R15279824 (WAVE 16M)
+            {ToDigest("dae2a8bc0fd3bcaf3f5e3ab6c4c6fd30e2663bf26ca17afe52924874c0afc4e2"), RomLocation::WAVEROM1},
+        },
+    },
+
+    ///////////////////////////////////////////////////////////////////////////
+    // SC-155 (rev 1)
+    ///////////////////////////////////////////////////////////////////////////
+    {
+        .name = "sc155-rev1",
+        .romset = Romset::SC155,
+        .hashes = {
+            // R15199799 (H8/532 mcu)
+            {ToDigest("24a65c97cdbaa847d6f59193523ce63c73394b4b693a6517ee79441f2fb8a3ee"), RomLocation::ROM1},
+            // R15209361 (H8/532 extra code)
+            {ToDigest("ceb7b9d3d9d264efe5dc3ba992b94f3be35eb6d0451abc574b6f6b5dc3db237b"), RomLocation::ROM2},
+            // R15209276 (WAVE A)
+            {ToDigest("5655509a531804f97ea2d7ef05b8fec20ebf46216b389a84c44169257a4d2007"), RomLocation::WAVEROM1},
+            // R15209277 (WAVE B)
+            {ToDigest("c655b159792d999b90df9e4fa782cf56411ba1eaa0bb3ac2bdaf09e1391006b1"), RomLocation::WAVEROM2},
+            // R15209281 (WAVE C)
+            {ToDigest("334b2d16be3c2362210fdbec1c866ad58badeb0f84fd9bf5d0ac599baf077cc2"), RomLocation::WAVEROM3},
+        },
+    },
+
+    // SC-155 (rev 2) omitted because ROM2 hash not available.
+
+    // CTF patched roms for backwards compatibility. These will be removed in the future.
+    MakeCtf(Romset::MK2, 0),
+    MakeCtf(Romset::MK2, 1),
+    MakeCtf(Romset::MK2, 2),
+    MakeCtf(Romset::MK2, 3),
+    MakeCtf(Romset::MK2, 4),
+    MakeCtf(Romset::MK2, 5),
+
+    MakeCtf(Romset::SC155MK2, 0),
+    MakeCtf(Romset::SC155MK2, 1),
+    MakeCtf(Romset::SC155MK2, 2),
+    MakeCtf(Romset::SC155MK2, 3),
+    MakeCtf(Romset::SC155MK2, 4),
+    MakeCtf(Romset::SC155MK2, 5),
+};
+
+// clang-format on
+
+std::span<const RomsetDefinition> GetStandardRomsetDefinitions()
+{
+    return STANDARD_ROMSET_DEFS;
+}

--- a/src/nuked-sc55/backend/standard_romsets.h
+++ b/src/nuked-sc55/backend/standard_romsets.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <span>
+
+#include "rom.h"
+
+std::span<const RomsetDefinition> GetStandardRomsetDefinitions();

--- a/src/nuked-sc55/backend/string_map.h
+++ b/src/nuked-sc55/backend/string_map.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+// Allows using string_view with unordered_map<string, ...>
+struct TransparentStringHash
+{
+    using is_transparent = void;
+
+    size_t operator()(const std::string& s) const
+    {
+        return std::hash<std::string>{}(s);
+    }
+
+    size_t operator()(std::string_view s) const
+    {
+        return std::hash<std::string_view>{}(s);
+    }
+};
+
+template <typename ValueType>
+using StringMap = std::unordered_map<std::string, ValueType, TransparentStringHash, std::equal_to<void>>;

--- a/src/nuked-sc55/backend/string_vector.h
+++ b/src/nuked-sc55/backend/string_vector.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+using StringVector = std::vector<std::string>;

--- a/src/nuked-sc55/backend/submcu.cpp
+++ b/src/nuked-sc55/backend/submcu.cpp
@@ -31,8 +31,9 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include "submcu.h"
+
+#include "diagnostics.h"
 #include "mcu.h"
 
 enum {
@@ -78,7 +79,7 @@ enum {
 
 void SM_ErrorTrap(submcu_t& sm)
 {
-    //fprintf(stderr, "%.4x\n", sm.pc);
+    Diag_Printf(Diag_Category::Debug, "%.4x\n", sm.pc);
 }
 
 uint8_t SM_Read(submcu_t& sm, uint16_t address)
@@ -144,7 +145,7 @@ uint8_t SM_Read(submcu_t& sm, uint16_t address)
     }
     else
     {
-        //fprintf(stderr, "sm: unknown read %x\n", address);
+        Diag_Printf(Diag_Category::Debug, "sm: unknown read %x\n", address);
         return 0;
     }
 }
@@ -204,7 +205,7 @@ void SM_Write(submcu_t& sm, uint16_t address, uint8_t data)
     }
     else
     {
-        //fprintf(stderr, "sm: unknown write %x %x\n", address, data);
+        Diag_Printf(Diag_Category::Debug, "sm: unknown write %x %x\n", address, data);
     }
 }
 
@@ -220,7 +221,7 @@ void SM_SysWrite(submcu_t& sm, uint32_t address, uint8_t data)
     else if (address >= 0xf8 && address < 0xfc)
     {
         sm.device_mode[SM_DEV_IPCM0 + (address & 3)] = data;
-        if ((address & 3) == 0)
+        if ((address & 3) == 0) 
         {
             sm.device_mode[SM_DEV_INT_REQUEST] |= 0x10;
             sm.device_mode[SM_DEV_SEMAPHORE] &= ~0x80;
@@ -245,7 +246,7 @@ void SM_SysWrite(submcu_t& sm, uint32_t address, uint8_t data)
     }
     else
     {
-        //fprintf(stderr, "sm: unknown sys write %x %x\n", address, data);
+        Diag_Printf(Diag_Category::Debug, "sm: unknown sys write %x %x\n", address, data);
     }
 }
 
@@ -286,7 +287,7 @@ uint8_t SM_SysRead(submcu_t& sm, uint32_t address)
     }
     else
     {
-        //fprintf(stderr, "sm: unknown sys read %x\n", address);
+        Diag_Printf(Diag_Category::Debug, "sm: unknown sys read %x\n", address);
         return 0;
     }
 }
@@ -513,7 +514,7 @@ void SM_Opcode_BBC_BBS(submcu_t& sm, uint8_t opcode)
     int8_t diff = (int8_t)SM_ReadAdvance(sm);
 
     int32_t set = (val >> bit) & 1;
-
+    
     if (set != type)
         sm.pc += (uint16_t)diff;
 }
@@ -1313,7 +1314,7 @@ void SM_HandleInterrupt(submcu_t& sm)
 {
     if (sm.sr & SM_STATUS_I)
         return;
-
+    
     if ((sm.device_mode[SM_DEV_UART1_CTRL] & 0x8) != 0
         && (sm.device_mode[SM_DEV_INT_ENABLE] & 0x80) != 0
         && (sm.device_mode[SM_DEV_INT_REQUEST] & 0x80) != 0)
@@ -1451,7 +1452,7 @@ void SM_Update(submcu_t& sm, uint64_t cycles)
         }
 
         sm.cycles += 12 * 4; // FIXME
-
+        
         SM_UpdateTimer(sm);
         SM_UpdateUART(sm);
     }

--- a/src/nuked-sc55/common/rom_loader.cpp
+++ b/src/nuked-sc55/common/rom_loader.cpp
@@ -1,5 +1,11 @@
 #include "rom_loader.h"
 
+#include <cstddef>
+#include <cstdio>
+
+#include "../backend/rom.h"
+#include "../backend/rom_io.h"
+
 namespace common
 {
 
@@ -17,6 +23,8 @@ const char* ToCString(LoadRomsetError error)
         return "Requested romset is incomplete";
     case LoadRomsetError::RomLoadFailed:
         return "Failed to load roms";
+    case LoadRomsetError::AmbiguousRomset:
+        return "Ambiguous romset";
     }
 
     if (error == LoadRomsetError{})
@@ -29,73 +37,155 @@ const char* ToCString(LoadRomsetError error)
     }
 }
 
-LoadRomsetError LoadRomset(AllRomsetInfo&               romset_info,
-                           const std::filesystem::path& rom_directory,
+void LoadRomsetResult::Purge()
+{
+    registries.hashes.Purge();
+}
+
+LoadRomsetError LoadRomset(const std::filesystem::path& rom_directory,
                            std::string_view             desired_romset,
-                           bool                         legacy_loader,
+                           RomLoader                    loader,
                            const RomOverrides&          overrides,
                            LoadRomsetResult&            result)
 {
-    if (desired_romset.size())
+    RomsetInfo&    romset_info = result.romset_info;
+    RomLocationSet desired     = ROMLOCATION_ALL;
+
+    // exclude roms with overrides - it doesn't matter if they're not on disk because the user has a different file to
+    // put there
+    for (size_t location = 0; location < ROMLOCATION_COUNT; ++location)
     {
-        if (!ParseRomsetName(desired_romset, result.romset))
+        if (!overrides[location].empty())
         {
+            desired[location]               = false;
+            romset_info.rom_paths[location] = overrides[location];
+        }
+    }
+
+    const bool is_romset_given  = desired_romset.size() > 0;
+    const bool is_romset_family = ParseRomsetName(desired_romset, result.romset);
+
+    switch (loader)
+    {
+    case RomLoader::Legacy:
+        if (is_romset_given && is_romset_family)
+        {
+            // we were explicitly given a valid name
+        }
+        else if (is_romset_given && !is_romset_family)
+        {
+            // user asked for an invalid name
             return LoadRomsetError::InvalidRomsetName;
         }
-
-        // When the user specifies a ROM set, we can speed up the loading process a bit.
-        RomLocationSet desired{};
-        desired[(size_t)result.romset] = true;
-
-        if (legacy_loader)
+        else if (!is_romset_given)
         {
-            if (!DetectRomsetsByFilename(rom_directory, romset_info, &desired))
+            // upstream defaults to mk2
+            result.romset = Romset::MK2;
+        }
+
+        SetRomsetFilenames(romset_info, rom_directory, result.romset, desired);
+
+        break;
+
+    case RomLoader::Hashing: {
+        // size of largest loadable rom (waverom expansion)
+        constexpr uintmax_t MAX_ROM_FILESIZE = (uintmax_t)0x800000;
+
+        constexpr auto FILTER_FILESIZE = [](const std::filesystem::directory_entry& ent) {
+            return ent.file_size() <= MAX_ROM_FILESIZE;
+        };
+
+        if (!HashDirectoryFiles(rom_directory, result.registries.hashes, FILTER_FILESIZE))
+        {
+            return LoadRomsetError::DetectionFailed;
+        }
+        result.registries.romsets = RomsetRegistry::CreateWithDefaultHashes();
+
+        StringVector romset_names;
+
+        if (is_romset_given && is_romset_family)
+        {
+            // we were given a family, so we need to pick a specific version from that family
+            GetCompleteRomsetNames(result.registries.romsets, result.registries.hashes, desired, romset_names);
+            if (romset_names.size() == 0)
             {
-                return LoadRomsetError::DetectionFailed;
+                return LoadRomsetError::NoCompleteRomsets;
+            }
+
+            bool        did_find_romset = false;
+            std::string picked_name;
+
+            for (const auto& name : romset_names)
+            {
+                Romset rs_family;
+                // ignored return: this function cannot fail because the name comes from GetCompleteRomsetNames, so it
+                // must be in the registry
+                (void)result.registries.romsets.GetRomsetFamily(name, rs_family);
+                if (rs_family == result.romset)
+                {
+                    if (did_find_romset)
+                    {
+                        return LoadRomsetError::AmbiguousRomset;
+                    }
+                    did_find_romset = true;
+                    picked_name     = name;
+                }
+            }
+
+            if (!did_find_romset)
+            {
+                return LoadRomsetError::NoCompleteRomsets;
+            }
+
+            if (!GetRomsetInfo(result.registries.romsets, picked_name, result.registries.hashes, desired, romset_info))
+            {
+                return LoadRomsetError::InvalidRomsetName;
+            }
+
+            result.picked_name = picked_name;
+        }
+        else if (is_romset_given && !is_romset_family)
+        {
+            // we were given a specific name
+            if (!GetRomsetInfo(
+                    result.registries.romsets, desired_romset, result.registries.hashes, desired, romset_info))
+            {
+                return LoadRomsetError::InvalidRomsetName;
+            }
+            // convert specific name to family name
+            if (!result.registries.romsets.GetRomsetFamily(desired_romset, result.romset))
+            {
+                return LoadRomsetError::InvalidRomsetName;
+            }
+
+            result.picked_name = desired_romset;
+        }
+        else if (!is_romset_given)
+        {
+            GetCompleteRomsetNames(result.registries.romsets, result.registries.hashes, ROMLOCATION_ALL, romset_names);
+
+            if (romset_names.size())
+            {
+                // Use the first returned name. The loaded romset will be essentially random if there is more than one
+                // in the rom directory.
+                // TODO: We may want to make this deterministic or an error in the future.
+
+                result.picked_name = romset_names.front();
+
+                // ignored returns: these names were returned by GetCompleteRomsetNames so the lookup cannot fail
+                (void)GetRomsetInfo(
+                    result.registries.romsets, result.picked_name, result.registries.hashes, desired, romset_info);
+                (void)result.registries.romsets.GetRomsetFamily(result.picked_name, result.romset);
+            }
+            else
+            {
+                return LoadRomsetError::NoCompleteRomsets;
             }
         }
-        else
-        {
-            if (!DetectRomsetsByHash(rom_directory, romset_info, &desired))
-            {
-                return LoadRomsetError::DetectionFailed;
-            }
-        }
+        break;
     }
-    else
-    {
-        // No user-specified romset; we'll use whatever romset we can find.
-        if (legacy_loader)
-        {
-            if (!DetectRomsetsByFilename(rom_directory, romset_info))
-            {
-                return LoadRomsetError::DetectionFailed;
-            }
-        }
-        else
-        {
-            if (!DetectRomsetsByHash(rom_directory, romset_info))
-            {
-                return LoadRomsetError::DetectionFailed;
-            }
-        }
-
-        if (!PickCompleteRomset(romset_info, result.romset))
-        {
-            return LoadRomsetError::NoCompleteRomsets;
-        }
-    }
-
-    for (size_t i = 0; i < ROMSET_COUNT; ++i)
-    {
-        for (size_t j = 0; j < ROMLOCATION_COUNT; ++j)
-        {
-            if (!overrides[j].empty())
-            {
-                romset_info.romsets[i].rom_paths[j] = overrides[j];
-                romset_info.romsets[i].rom_data[j].clear();
-            }
-        }
+    default:
+        return LoadRomsetError::DetectionFailed;
     }
 
     if (!IsCompleteRomset(romset_info, result.romset, &result.completion))
@@ -103,7 +193,7 @@ LoadRomsetError LoadRomset(AllRomsetInfo&               romset_info,
         return LoadRomsetError::IncompleteRomset;
     }
 
-    if (!LoadRomset(result.romset, romset_info, &result.loaded))
+    if (!LoadRomset(romset_info, &result.loaded))
     {
         return LoadRomsetError::RomLoadFailed;
     }
@@ -113,108 +203,182 @@ LoadRomsetError LoadRomset(AllRomsetInfo&               romset_info,
 
 void PrintRomsets(FILE* output)
 {
-    //fprintf(output, "Accepted romset names:\n");
-    //fprintf(output, "  ");
-    //for (const char* name : GetParsableRomsetNames())
-    //{
-    //    fprintf(output, "%s ", name);
-    //}
-    //fprintf(output, "\n\n");
+    RomsetRegistry romsets = RomsetRegistry::CreateWithDefaultHashes();
+    StringVector   specific_names;
+
+    fprintf(output, "Accepted romset names:\n");
+    for (size_t i = 0; i < ROMSET_COUNT; ++i)
+    {
+        Romset romset = (Romset)i;
+        fprintf(output, "  %s\n", ParsableRomsetName(romset));
+
+        romsets.GetNamesForFamily(romset, specific_names);
+        for (const auto& spec_name : specific_names)
+        {
+            // deduplicate - some romset families only have one specific romset
+            // in that case we give them the same name
+            if (spec_name != ParsableRomsetName(romset))
+            {
+                fprintf(output, "      %s\n", spec_name.c_str());
+            }
+        }
+    }
+    fprintf(output, "\n");
 }
 
-void PrintLoadRomsetDiagnostics(FILE*                   output,
-                                LoadRomsetError         error,
-                                const LoadRomsetResult& result,
-                                const AllRomsetInfo&    info)
+void PrintLoadRomsetDiagnostics(FILE* output, LoadRomsetError error, const LoadRomsetResult& result)
 {
-    //switch (error)
-    //{
-    //case LoadRomsetError::DetectionFailed:
-    //    // TODO: DetectRomsets* will print its own diagnostics
-    //    break;
-    //case LoadRomsetError::InvalidRomsetName:
-    //    fprintf(output, "error: %s\n", ToCString(error));
-    //    PrintRomsets(output);
-    //    break;
-    //case LoadRomsetError::NoCompleteRomsets:
-    //    fprintf(output, "No complete romsets found.\n");
-    //    for (size_t rs = 0; rs < ROMSET_COUNT; ++rs)
-    //    {
-    //        RomCompletionStatusSet completion;
-    //
-    //        (void)IsCompleteRomset(info, (Romset)rs, &completion);
-    //
-    //        if (CountPresent(completion))
-    //        {
-    //            fprintf(output, "Romset %s partially complete:\n", RomsetName((Romset)rs));
-    //            for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
-    //            {
-    //                if (completion[i] != RomCompletionStatus::Unused)
-    //                {
-    //                    fprintf(output, "  * %7s: %-12s", ToCString(completion[i]), ToCString((RomLocation)i));
-    //
-    //                    if (completion[i] == RomCompletionStatus::Present)
-    //                    {
-    //                        fprintf(output, "%s\n", info.romsets[rs].rom_paths[i].generic_string().c_str());
-    //                    }
-    //                    else
-    //                    {
-    //                        fprintf(output, "\n");
-    //                    }
-    //                }
-    //            }
-    //        }
-    //    }
-    //    break;
-    //case LoadRomsetError::IncompleteRomset:
-    //    fprintf(output, "Romset %s is incomplete:\n", RomsetName(result.romset));
-    //    for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
-    //    {
-    //        if (result.completion[i] != RomCompletionStatus::Unused)
-    //        {
-    //            fprintf(output, " * %7s: %-12s", ToCString(result.completion[i]), ToCString((RomLocation)i));
-    //
-    //            if (result.completion[i] == RomCompletionStatus::Present)
-    //            {
-    //                fprintf(output, "%s\n", info.romsets[(size_t)result.romset].rom_paths[i].generic_string().c_str());
-    //            }
-    //            else
-    //            {
-    //                fprintf(output, "\n");
-    //            }
-    //        }
-    //    }
-    //    break;
-    //case LoadRomsetError::RomLoadFailed:
-    //    fprintf(output, "Failed to load some %s roms:\n", RomsetName(result.romset));
-    //    for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
-    //    {
-    //        if (result.loaded[i] != RomLoadStatus::Unused)
-    //        {
-    //            fprintf(output,
-    //                    "  * %s: %-12s %s\n",
-    //                    ToCString(result.loaded[i]),
-    //                    ToCString((RomLocation)i),
-    //                    info.romsets[(size_t)result.romset].rom_paths[i].generic_string().c_str());
-    //        }
-    //    }
-    //    break;
-    //}
-    //
-    //if (error == LoadRomsetError{})
-    //{
-    //    fprintf(output, "Using %s romset:\n", RomsetName(result.romset));
-    //    for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
-    //    {
-    //        if (result.loaded[i] == RomLoadStatus::Loaded)
-    //        {
-    //            fprintf(output,
-    //                    "  * %-12s %s\n",
-    //                    ToCString((RomLocation)i),
-    //                    info.romsets[(size_t)result.romset].rom_paths[i].generic_string().c_str());
-    //        }
-    //    }
-    //}
+    switch (error)
+    {
+    case LoadRomsetError::DetectionFailed:
+        // TODO: DetectRomsets* will print its own diagnostics
+        break;
+    case LoadRomsetError::InvalidRomsetName:
+        fprintf(output, "error: %s\n", ToCString(error));
+        PrintRomsets(output);
+        break;
+    case LoadRomsetError::NoCompleteRomsets: {
+        fprintf(output, "No complete romsets for %s found.\n", ParsableRomsetName(result.romset));
+
+        StringVector partial_names;
+        GetPartialRomsetNames(result.registries.romsets, result.registries.hashes, ROMLOCATION_ALL, partial_names);
+
+        for (const auto& name : partial_names)
+        {
+            Romset                 family;
+            RomsetInfo             info;
+            RomCompletionStatusSet completion;
+
+            (void)result.registries.romsets.GetRomsetFamily(name, family);
+            (void)GetRomsetInfo(result.registries.romsets, name, result.registries.hashes, ROMLOCATION_ALL, info);
+
+            bool complete = IsCompleteRomset(info, family, &completion);
+
+            const char* format;
+            if (complete)
+            {
+                format = "Romset %s (%s) complete:\n";
+            }
+            else
+            {
+                format = "Romset %s (%s) partially complete:\n";
+            }
+
+            fprintf(output, format, name.c_str(), RomsetName(family));
+            for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
+            {
+                if (completion[i] != RomCompletionStatus::Unused)
+                {
+                    fprintf(output, "  * %7s: %-12s", ToCString(completion[i]), ToCString((RomLocation)i));
+
+                    if (completion[i] == RomCompletionStatus::Present)
+                    {
+                        fprintf(output, "%s\n", info.rom_paths[i].generic_string().c_str());
+                    }
+                    else
+                    {
+                        fprintf(output, "\n");
+                    }
+                }
+            }
+        }
+
+        break;
+    }
+    case LoadRomsetError::IncompleteRomset:
+        fprintf(output, "Romset %s is incomplete:\n", RomsetName(result.romset));
+        for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
+        {
+            if (result.completion[i] != RomCompletionStatus::Unused)
+            {
+                fprintf(output, "  * %7s: %-12s", ToCString(result.completion[i]), ToCString((RomLocation)i));
+
+                if (result.completion[i] == RomCompletionStatus::Present)
+                {
+                    fprintf(output, "%s\n", result.romset_info.rom_paths[i].generic_string().c_str());
+                }
+                else
+                {
+                    fprintf(output, "\n");
+                }
+            }
+        }
+        break;
+    case LoadRomsetError::RomLoadFailed:
+        fprintf(output, "Failed to load some %s roms:\n", RomsetName(result.romset));
+        for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
+        {
+            if (result.loaded[i] != RomLoadStatus::Unused)
+            {
+                fprintf(output,
+                        "  * %s: %-12s %s\n",
+                        ToCString(result.loaded[i]),
+                        ToCString((RomLocation)i),
+                        result.romset_info.rom_paths[i].generic_string().c_str());
+            }
+        }
+        break;
+    case LoadRomsetError::AmbiguousRomset: {
+        fprintf(output, "Requested romset `%s` is ambiguous:\n", ParsableRomsetName(result.romset));
+
+        StringVector names;
+        for (const RomsetDefinition& def : result.registries.romsets)
+        {
+            // Currently, ambiguity only happens when the user writes a family name but there are multiple romsets
+            // under that family in the rom directory. e.g. "--romset jv880" with the directory containing both
+            // "jv880-v1.0.0" and "jv880-v1.0.1"
+            //
+            // This may change in the future if we decide it is ambiguous to leave --romset unspecified when multiple
+            // romsets of any kind are present.
+            if (def.romset != result.romset)
+            {
+                continue;
+            }
+
+            RomCompletionStatusSet completion;
+            if (GetDefinitionCompletion(def, result.registries.hashes, ROMLOCATION_ALL, completion))
+            {
+                fprintf(output, "Found %s:\n", def.name);
+
+                for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
+                {
+                    if (completion[i] == RomCompletionStatus::Present)
+                    {
+                        fprintf(output,
+                                "  * %7s: %-12s %s\n",
+                                ToCString(completion[i]),
+                                ToCString((RomLocation)i),
+                                result.registries.hashes.GetFile(def.GetHash((RomLocation)i))
+                                    ->path.generic_string()
+                                    .c_str());
+                    }
+                }
+            }
+        }
+    }
+    }
+
+    if (error == LoadRomsetError{})
+    {
+        if (result.picked_name.size())
+        {
+            fprintf(output, "Using %s romset %s:\n", RomsetName(result.romset), result.picked_name.c_str());
+        }
+        else
+        {
+            fprintf(output, "Using %s romset:\n", RomsetName(result.romset));
+        }
+        for (size_t i = 0; i < ROMLOCATION_COUNT; ++i)
+        {
+            if (result.loaded[i] == RomLoadStatus::Loaded)
+            {
+                fprintf(output,
+                        "  * %-12s %s\n",
+                        ToCString((RomLocation)i),
+                        result.romset_info.rom_paths[i].generic_string().c_str());
+            }
+        }
+    }
 }
 
 } // namespace common

--- a/src/nuked-sc55/common/rom_loader.h
+++ b/src/nuked-sc55/common/rom_loader.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../backend/file_hashing.h"
 #include "../backend/rom_io.h"
 
 namespace common
@@ -22,28 +23,60 @@ enum class LoadRomsetError
 
     // loaded roms will be available through `loaded`
     RomLoadFailed,
+
+    // user requested a romset family, but there are multiple suitable romsets in the rom directory
+    AmbiguousRomset,
 };
 
 // `error`: error code to convert to string
 const char* ToCString(LoadRomsetError error);
 
+struct LoaderRegistries
+{
+    HashedFileRegistry hashes;
+    RomsetRegistry     romsets;
+};
+
 struct LoadRomsetResult
 {
     Romset romset;
 
+    // on successful load, this field contains the paths and data for each rom location
+    RomsetInfo romset_info;
+
     RomLoadStatusSet       loaded;
     RomCompletionStatusSet completion;
+
+    LoaderRegistries registries;
+
+    std::string picked_name;
+
+    // Frees any allocated buffers from loading roms and hashing files. This happens automatically when the result
+    // object goes out of scope, but it is useful in cases where we keep the result object around and no longer need
+    // the data.
+    void Purge();
 };
 
-// `romset_info`: receives rom paths and rom data
+enum class RomLoader
+{
+    // takes the SHA256 hash of files in the rom directory and locates roms to load regardless of filename
+    Hashing,
+
+    // load specific filenames using the same logic as nukeykt/Nuked-SC55
+    Legacy,
+};
+
 // `rom_directory`: directory containing complete romset(s)
-// `desired_romset`: romset the user wants to load; if empty string the first romset in the directory will be returned
-// `legacy_loader`: use the same logic as nukeykt/Nuked-SC55
-// `result`: receives the loaded romset and information about which roms were loaded
-LoadRomsetError LoadRomset(AllRomsetInfo&               romset_info,
-                           const std::filesystem::path& rom_directory,
+// `desired_romset`: romset the user wants to load; if empty this defaults to mk2 for the legacy loader and the first
+//                   detected romset in `rom_directory` for the hashing loader
+// `loader`: which loader to use
+// `overrides`: overrides for specific roms in the romset
+// `result`: receives the results of loading `desired_romset`
+//
+// Returns `LoadRomsetError{}` on success.
+LoadRomsetError LoadRomset(const std::filesystem::path& rom_directory,
                            std::string_view             desired_romset,
-                           bool                         legacy_loader,
+                           RomLoader                    loader,
                            const RomOverrides&          overrides,
                            LoadRomsetResult&            result);
 
@@ -53,10 +86,6 @@ void PrintRomsets(FILE* output);
 // `output`: where to write diagnostics to
 // `error`: error to write diagnostics for
 // `results`: results object to take diagnostics information from
-// `info`: romset info passed to `LoadRomset`
-void PrintLoadRomsetDiagnostics(FILE*                   output,
-                                LoadRomsetError         error,
-                                const LoadRomsetResult& result,
-                                const AllRomsetInfo&    info);
+void PrintLoadRomsetDiagnostics(FILE* output, LoadRomsetError error, const LoadRomsetResult& result);
 
 } // namespace common

--- a/src/nuked_sc55.cpp
+++ b/src/nuked_sc55.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include "nuked_sc55.h"
+#include "nuked-sc55/backend/diagnostics.h"
 #include "nuked-sc55/common/rom_loader.h"
 
 static std::string get_env_var(const char* var_name);
@@ -165,6 +166,10 @@ bool NukedSc55::Init(const clap_plugin* _plugin_instance)
 
     plugin_instance = _plugin_instance;
 
+    // Disable jcmoyer/Nuked-SC55's diagnostics output (defaults to stderr) - a plugin has no
+    // attached console, and some of these calls are reachable from the audio thread.
+    Diag_SetCallback(nullptr);
+
     emu = std::make_unique<Emulator>();
 
     const EMU_Options opts = {.lcd_backend = nullptr, .nvram_filename = std::filesystem::path{}};
@@ -194,16 +199,16 @@ bool NukedSc55::Init(const clap_plugin* _plugin_instance)
 
         log("Trying ROM dir: %s", rom_path.string().c_str());
 
-        AllRomsetInfo romset_info = {};
         common::LoadRomsetResult load_result = {};
         common::RomOverrides rom_overrides;
-        common::LoadRomsetError err = common::LoadRomset(romset_info, rom_path, romset, false, rom_overrides, load_result);
+        common::LoadRomsetError err =
+            common::LoadRomset(rom_path, romset, common::RomLoader::Hashing, rom_overrides, load_result);
         if (err != common::LoadRomsetError{}) {
             log("emu->LoadRomset failed. Trying next directory");
             continue;
         }
         RomLocationSet loaded = {};
-        if (!emu->LoadRoms(load_result.romset, romset_info, &loaded)) {
+        if (!emu->LoadRoms(load_result.romset, load_result.romset_info, &loaded)) {
             log("emu->LoadRoms failed");
             emu.reset(nullptr);
             return false;


### PR DESCRIPTION
## Summary

The vendored backend under `src/nuked-sc55/` was pinned at jcmoyer/Nuked-SC55 commit `0be4ab0` (2025-11-19), 16 commits behind current `master`. This brings it up to date.

Most notably this picks up jcmoyer's romset-completeness rework (`89ce9cb63`, a 65-commit rollup): the old detection logic tracked ROM completeness per coarse `Romset` enum only, so a ROM1 from one named hardware revision paired with a ROM2 from a *different* revision of the same family could be silently accepted as a "complete" romset despite being an incompatible mismatch. The new code validates named romset definitions as whole units instead.

Also picked up:
- New ROM hash tables: SC-55 mk1 v1.00 through v2.00 (previously mk2 v1.01 was the best-covered model), JV-880 v1.0.0/v1.0.1, CM-300/SCC-1/SCC-1A, SCB-55/RLP-3194, RLP-3237, SC-155, plus CTF-patched SC-55mk2/SC-155mk2 hashes.
- jcmoyer's new `Diag_Printf`/`Diag_SetCallback` logging module, replacing raw `fprintf(stderr, ...)` calls throughout the backend. Wired `Diag_SetCallback(nullptr)` into `NukedSc55::Init()` to preserve this plugin's existing "no console output" behavior (a CLAP plugin has no attached console, and some of the calls this replaces are reachable from the audio thread).

The actual change to `nuked_sc55.cpp` is small — `AllRomsetInfo` was folded into `LoadRomsetResult::romset_info`, and `LoadRomset()`'s `bool legacy_loader` became a `RomLoader` enum:

```cpp
common::LoadRomsetResult load_result = {};
common::RomOverrides rom_overrides;
common::LoadRomsetError err =
    common::LoadRomset(rom_path, romset, common::RomLoader::Hashing, rom_overrides, load_result);
...
if (!emu->LoadRoms(load_result.romset, load_result.romset_info, &loaded)) {
```

Note: this PR only syncs the backend and hash tables. `NukedSc55::Model` still only exposes SC-55 mk1/mk2 as selectable models, so JV-880/CM-300/SC-155/etc. aren't loadable yet even though their ROMs are now correctly detected — adding them as selectable models would be a separate follow-up.

## Test plan

- [x] Clean build against unmodified `main` (`debug-linux-syslibs-x64` preset, no other local changes)
- [x] Verified via `dosbox-staging` (which uses this plugin's CLAP extension query, unused by this PR) that a real SC-55mk2 v1.01 romset still loads and initializes correctly
- [x] Verified a real SC-55 mk1 v1.21 romset (sourced from a MAME romset, SHA256-checked against the new hash table) loads and initializes correctly — this exercises entirely new code paths not previously reachable
- [x] Deliberately broke a romset (removed one required file) and confirmed it's still rejected cleanly with a graceful fallback, same as before the sync